### PR TITLE
Setting 'active' with 0 for new users

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -142,7 +142,8 @@ class UsersController extends UsersAppController {
 					'password' => 'password'),
 				'userModel' => 'Users.User', 
 				'scope' => array(
-					'User.active' => 1)));
+					'User.active' => 1,
+					'User.email_verified' => 1)));
 
 		$this->Auth->loginRedirect = '/';
 		$this->Auth->logoutRedirect = '/';


### PR DESCRIPTION
Users can be logged in without verify email account, because default behavior is save 'active' with 1, and that is the only scope delimitation at authentication logic.

So, now, if the user had not verified their email account, he will not able to gain authentication into the system.
