### PR TITLE
Allow hashing method to be overridden

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -238,6 +238,22 @@ class User extends UsersAppModel {
 	}
 
 /**
+ * Create a hash from string using given method.
+ * Fallback on next available method.
+ *
+ * Override this method to use a different hashing method
+ *
+ * @param string $string String to hash
+ * @param string $type Method to use (sha1/sha256/md5)
+ * @param boolean $salt If true, automatically appends the application's salt
+ *     value to $string (Security.salt)
+ * @return string Hash
+ */
+	public function hash($string, $type = null, $salt = false) {
+		return Security::hash($string, $type, $salt);
+	}
+
+/**
  * Custom validation method to ensure that the two entered passwords match
  *
  * @param string $password Password
@@ -335,7 +351,7 @@ class User extends UsersAppModel {
 
 				if ($reset === true) {
 					$newPassword = $this->generatePassword();
-					$data[$this->alias]['password'] = Security::hash($newPassword, null, true);
+					$data[$this->alias]['password'] = $this->hash($newPassword, null, true);
 					$data[$this->alias]['new_password'] = $newPassword;
 					$data[$this->alias]['password_token'] = null;
 				}
@@ -433,7 +449,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$this->data[$this->alias]['password'] = Security::hash($this->data[$this->alias]['new_password'], null, true);
+			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password'], null, true);
 			$this->data[$this->alias]['password_token'] = null;
 			$result = $this->save($this->data, array(
 				'validate' => false,
@@ -455,7 +471,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$this->data[$this->alias]['password'] = Security::hash($this->data[$this->alias]['new_password'], null, true);
+			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password'], null, true);
 			$this->save($postData, array(
 				'validate' => false,
 				'callbacks' => false));
@@ -478,7 +494,7 @@ class User extends UsersAppModel {
 		}
 
 		$currentPassword = $this->field('password', array($this->alias . '.id' => $this->data[$this->alias]['id']));
-		return $currentPassword === Security::hash($password['old_password'], null, true);
+		return $currentPassword === $this->hash($password['old_password'], null, true);
 	}
 
 /**
@@ -554,7 +570,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$postData[$this->alias]['password'] = Security::hash($postData[$this->alias]['password'], 'sha1', true);
+			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);
 			$this->create();
 			$this->data = $this->save($postData, false);
 			$this->data[$this->alias]['id'] = $this->id;

--- a/Test/Case/Model/UserTest.php
+++ b/Test/Case/Model/UserTest.php
@@ -211,7 +211,7 @@ class UserTestCase extends CakeTestCase {
  * @return void
  */
 	public function testValidateOldPassword() {
-		$password = Security::hash('password', null, true);
+		$password = $this->User->hash('password', null, true);
 		$this->User->id = '1';
 		$this->User->saveField('password', $password);
 		$this->User->data = array(
@@ -282,7 +282,7 @@ class UserTestCase extends CakeTestCase {
 		$result = $this->User->data;
 
 		$this->assertEqual($result['User']['active'], 1);
-		$this->assertEqual($result['User']['password'], Security::hash('password', 'sha1', true));
+		$this->assertEqual($result['User']['password'], $this->User->hash('password', 'sha1', true));
 		$this->assertTrue(is_string($result['User']['email_token']));
 
 		$result = $this->User->findById($this->User->id);
@@ -322,7 +322,7 @@ class UserTestCase extends CakeTestCase {
 			'recursive' => -1,
 			'conditions' => array(
 				'User.id' => 1)));
-		$this->assertEqual($ressult['User']['password'], Security::hash('testtest', null, true));
+		$this->assertEqual($ressult['User']['password'], $this->User->hash('testtest', null, true));
 	}
 
 /**

--- a/Test/Fixture/UserFixture.php
+++ b/Test/Fixture/UserFixture.php
@@ -9,8 +9,6 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-App::uses('Security', 'Utility');
-
 /**
  * UserFixture
  *
@@ -188,8 +186,9 @@ class UserFixture extends CakeTestFixture {
  */
 	public function __construct() {
 		parent::__construct();
+		$this->User = ClassRegistry::init('Users.User');
 		foreach ($this->records as &$record) {
-			$record['password'] = Security::hash($record['password'], null, true);
+			$record['password'] = $this->User->hash($record['password'], null, true);
 		}
 	}
 


### PR DESCRIPTION
This allows you to extend the User model to use a different hashing method, such as Bcrypt.
