### PR TITLE
CRITICAL security issue on registration

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -568,6 +568,10 @@ class User extends UsersAppModel {
 			$this->_removeExpiredRegistrations();
 		}
 
+		if (!empty($postData[$this->alias]['is_admin'])) {
+			unset($postData[$this->alias]['is_admin']);
+		}
+
 		$this->set($postData);
 		if ($this->validates()) {
 			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);


### PR DESCRIPTION
The postData param is_admin is not removed from the data array, so anyone that injects the value with HTML/Javascript can be registered as admin.
