### PR TITLE
Remember me cookie name / key were swapped

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -652,13 +652,13 @@ class UsersController extends UsersAppController {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html
  */
-	protected function _setCookie($options = array(), $cookieKey = 'User') {
+	protected function _setCookie($options = array(), $cookieKey = 'rememberMe') {
 		if (empty($this->request->data[$this->modelClass]['remember_me'])) {
 			$this->Cookie->delete($cookieKey);
 		} else {
 			$validProperties = array('domain', 'key', 'name', 'path', 'secure', 'time');
 			$defaults = array(
-				'name' => 'rememberMe');
+				'name' => 'Users');
 
 			$options = array_merge($defaults, $options);
 			foreach ($options as $key => $value) {


### PR DESCRIPTION
The cookie was called rememberMe and within that cookie, the variable was called User. So the effect was a cookie in the browser called rememberMe[User]. This is the opposite of the code in the readme to be inserted into AppController, where it had cookie name "Users" and key "rememberMe".

I changed the _setCookie() function to set a cookie called Users[rememberMe] which seems like the more sensible path, and matches the readme.

Having made this change, I have another issue. I delete my session cookies, leaving the Users[rememberMe] cookie, and then try to access a restricted method. The `$this->Auth->login($data);` in AppController returns `true`, I am logged in, and I can access controller methods which are not visible to anonymous users. However, `debug($this->Auth->user('id'));` shows `null`.

I'm not familiar enough with cakephp to know what's going on. I do know that after a form based login, `$this->Auth->user('id')` returns the currently logged in user's id. So something appears to be different between a cookie based login and a form login.
