### PR TITLE
Prevent login action for users already logged in

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -347,6 +347,10 @@ class UsersController extends UsersAppController {
  * @return void
  */
 	public function login() {
+		if ($this->Auth->user()) {
+			$this->Session->setFlash(__d('users', 'You are already registered and logged in!'));
+			$this->redirect('/');
+		}
 		if ($this->request->is('post')) {
 			if ($this->Auth->login()) {
 				$this->User->id = $this->Auth->user('id');


### PR DESCRIPTION
When a user is logged in they are prevented from seeing the register page. I added the same functionality to the login page for users already logged in.
