### PR TITLE
Session::setFlash instead of Auth::flash

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -376,7 +376,7 @@ class UsersController extends UsersAppController {
 
 				$this->redirect($this->Auth->redirect($data['return_to']));
 			} else {
-				$this->Auth->flash(__d('users', 'Invalid e-mail / password combination.  Please try again'));
+				$this->Session->setFlash(__d('users', 'Invalid e-mail / password combination.  Please try again'));
 			}
 		}
 		if (isset($this->request->params['named']['return_to'])) {


### PR DESCRIPTION
$this->Session->setFlash() is used everywhere except in login where $this->Auth->flash() is used. By default, messages set via $this->Auth->flash() will not be output anywhere. I'm guessing this is a mistake and not deliberate, but if not, please disregard this patch.
