### PR TITLE
UsersControllerTestCase inheritance

### DIFF
--- a/Test/Case/Controller/UsersControllerTest.php
+++ b/Test/Case/Controller/UsersControllerTest.php
@@ -187,7 +187,7 @@ class UsersControllerTestCase extends CakeTestCase {
  *
  * @return void
  */
-	public function startTest() {
+	public function startTest($method) {
 		Configure::write('App.UserClass', null);
 
 		$request = new CakeRequest();
@@ -597,7 +597,7 @@ class UsersControllerTestCase extends CakeTestCase {
  *
  * @return void
  */
-	public function endTest() {
+	public function endTest($method) {
 		$this->Users->Session->destroy();
 		unset($this->Users);
 		ClassRegistry::flush();


### PR DESCRIPTION
By PHP5.4 strict standards, startTest() and endTest() lacked the $method var in the definition.
