### PR TITLE
Fixed typo - syntax when calling __d()

### DIFF
--- a/Controller/Component/RememberMeComponent.php
+++ b/Controller/Component/RememberMeComponent.php
@@ -216,7 +216,7 @@ class RememberMeComponent extends Component {
 			if (in_array($key, $validProperties)) {
 				$this->Cookie->{$key} = $value;
 			} else {
-				throw new InvalidArgumentException(__('users', 'Invalid options %s', $key));
+				throw new InvalidArgumentException(__d('users', 'Invalid options %s', $key));
 			}
 		}
 	}


### PR DESCRIPTION
I had posted this PR before but did it from my develop branch. GitHub auto-closed the PR once I merged branches. Here is the PR again.
