### PR TITLE
Add feedback to the user

### DIFF
--- a/View/Users/login.ctp
+++ b/View/Users/login.ctp
@@ -11,6 +11,7 @@
 ?>
 <div class="users index">
 	<h2><?php echo __d('users', 'Login'); ?></h2>
+	<?php echo $this->Session->flash('auth');?>
 	<fieldset>
 		<?php
 			echo $this->Form->create($model, array(


### PR DESCRIPTION
When a user fails to provide correct details a flash message is set but never displayed. I've just added the output for this to the login form, as I override this in every project I do, it's about time to send a PR.

Apologies for including the merge commit, but I'm not sure how to remove it and I struggled to get rid of it by squashing.
