### PR TITLE
Updating afterSave method signature

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -207,9 +207,10 @@ class User extends UsersAppModel {
  * After save callback
  *
  * @param boolean $created
+ * @param array $options
  * @return void
  */
-	public function afterSave($created) {
+	public function afterSave($created, $options = array()) {
 		if ($created) {
 			$this->sluggedUserUrl();
 		}


### PR DESCRIPTION
Strict compliance with new CakePhp 2.4.1, see
http://bakery.cakephp.org/articles/markstory/2013/09/15/cakephp_2_4_1_released

Method signatures of Behavior callbacks was corrected. If you are using PHP5.4 you may have to update the method signatures of your behaviors to resolve any E_STRICT errors.

Sending pull request for master since develop no longer contains this method.
