### PR TITLE
Update composer.json cakedc/search dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
-        "composer/installers": "*"
+        "composer/installers": "*",
+        "cakedc/search": "*"
     }
 }


### PR DESCRIPTION
Why not to add dependency with search plugin in the composer plugin?
