### PR TITLE
User password edit / unit tests

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -829,7 +829,7 @@ class User extends UsersAppModel {
 			throw new NotFoundException(__d('users', 'Invalid User'));
 		}
 
-		if(!empty($postData)) {
+		if (!empty($postData)) {
 			$this->set($postData);
 			if ($this->validates()) {
 				if(isset($this->data[$this->alias]['password'])) {

--- a/Test/Case/Model/UserTest.php
+++ b/Test/Case/Model/UserTest.php
@@ -62,7 +62,7 @@ class UserTestCase extends CakeTestCase {
 	}
 
 /**
- *
+ * Test User Instance
  *
  * @return void
  */
@@ -105,7 +105,7 @@ class UserTestCase extends CakeTestCase {
  *
  * @return void
  */
-	function testGenerateToken() {
+	public function testGenerateToken() {
 		$result = $this->User->generateToken();
 		$this->assertInternalType('string', $result);
 	}


### PR DESCRIPTION
Users could not properly update their password using the User::edit
method.

The User::resetPassword also had validation commented out, which caused
unit tests to fail and thus password resets didn’t validate properly.

First off, there was a unit test for a method that no longer existed.
Also updated a few exception tests that were incorrect. Added tests for
user password edits.
