### PR TITLE
Rehashing fetched password

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -832,8 +832,8 @@ class User extends UsersAppModel {
 		if (!empty($postData)) {
 			$this->set($postData);
 			if ($this->validates()) {
-				if(isset($this->data[$this->alias]['password'])) {
-					$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['password'], 'sha1', true);
+				if(isset($postData[$this->alias]['password'])) {
+					$this->data[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);
 				}
 				$result = $this->save(null, false);
 				if ($result) {

--- a/Test/Case/Model/UserTest.php
+++ b/Test/Case/Model/UserTest.php
@@ -427,14 +427,21 @@ class UserTestCase extends CakeTestCase {
  **/
 	public function testEditPassword() {
 		$userId = '1';
-		$data = $this->User->read(null, $userId);
-		$data['User']['email'] = 'anotherNewEmail@anothernewemail.com';
-		$data['User']['password'] = 'anotherNewPassword';
-		$data['User']['temppassword'] = 'anotherNewPassword';
 
-		$result = $this->User->edit(1, $data);
+		$data1 = $this->User->read(null, $userId);
 
-		$hashPassword = $this->User->hash($data['User']['password'], 'sha1', true);
+		$data['User']['email'] = 'emailUpdate@anotheremail.com';
+		$result = $this->User->edit($userId, $data);
+		$this->assertTrue($result);
+		$this->assertEquals($this->User->data['User']['password'], $data1['User']['password']);
+
+		$data1['User']['email'] = 'anotherNewEmail@anothernewemail.com';
+		$data1['User']['password'] = 'anotherNewPassword';
+		$data1['User']['temppassword'] = 'anotherNewPassword';
+
+		$result = $this->User->edit($userId, $data1);
+
+		$hashPassword = $this->User->hash($data1['User']['password'], 'sha1', true);
 		$this->assertTrue($result);
 		$this->assertEquals($this->User->data['User']['password'], $hashPassword);
 


### PR DESCRIPTION
This fixes rehashing the password when the password is not passed in the postData. The issue here is if a password was not passed, the user is fetched from the datasource and then the hashed password is rehashed. This results in rehashing a hash, which in turn unexpectedly updates the password as a hash of a hash. Accompanied by test updating single field and not modifying password.
