### PR TITLE
Corrected link for installing as a git submodule

### DIFF
--- a/Docs/Documentation/Installation.md
+++ b/Docs/Documentation/Installation.md
@@ -9,7 +9,7 @@ Git Submodule
 If you're using git for version control, you may want to add the **Users** plugin as a submodule on your repository. To do so, run the following command from the base of your repository:
 
 ```
-git submodule add git@github.com:CakeDC/migrations.git app/Plugin/Users
+git submodule add git@github.com:CakeDC/users.git app/Plugin/Users
 ```
 
 After doing so, you will see the submodule in your changes pending, plus the file ".gitmodules". Simply commit and push to your repository.


### PR DESCRIPTION
The url to add the git submodule from was pointing to migrations instead of users.
