### PR TITLE
Fixing login.ctp

### DIFF
--- a/View/Users/login.ctp
+++ b/View/Users/login.ctp
@@ -15,7 +15,6 @@
 	<fieldset>
 		<?php
 			echo $this->Form->create($model, array(
-				'action' => 'login',
 				'id' => 'LoginForm'));
 			echo $this->Form->input('email', array(
 				'label' => __d('users', 'Email')));


### PR DESCRIPTION
Before removing 'action' key the output is WRONG :
<form action="/users/app_users/login" id="LoginForm"

After removing 'action' key the output is VERY GOOD! 
<form action="/users/login" id="LoginForm"

My goal is I need to detect logged in user. If logged in user is 'admin' then i need to modifiy $this->Auth->loginRedirect to /admin/users otherwise 
to /users. So.. i create http://pastebin.com/CwZE3qsM to achieve my goal. 

Then modify app/Plugin/Users/Config/routes.php
Router::connect('/users/:action/*', array('plugin' => null, 'controller' => 'app_users'));
if 'action' not removed, i get wrong output.

I think not only me will need to override the CakeDC's Users plugin .
