### PR TITLE
User hash method

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -194,7 +194,7 @@ class User extends UsersAppModel {
  *	 value to $string (Security.salt)
  * @return string Hash
  */
-	public function hash($string, $type = null, $salt = false) {
+	public function hash($string, $type = null, $salt = true) {
 		return Security::hash($string, $type, $salt);
 	}
 
@@ -381,7 +381,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password'], null, true);
+			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password']);
 			$this->data[$this->alias]['password_token'] = null;
 			$result = $this->save($this->data, array(
 				'validate' => false,
@@ -404,7 +404,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password'], null, true);
+			$this->data[$this->alias]['password'] = $this->hash($this->data[$this->alias]['new_password']);
 			$this->save($postData, array(
 				'validate' => false,
 				'callbacks' => $this->enableCallbacks));
@@ -428,7 +428,7 @@ class User extends UsersAppModel {
 		}
 
 		$currentPassword = $this->field('password', array($this->alias . '.id' => $this->data[$this->alias]['id']));
-		return $currentPassword === $this->hash($password['old_password'], null, true);
+		return $currentPassword === $this->hash($password['old_password']);
 	}
 
 /**
@@ -574,7 +574,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
+			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password']);
 			$this->create();
 			$this->data = $this->save($postData, false);
 			$this->data[$this->alias]['id'] = $this->id;
@@ -830,7 +830,7 @@ class User extends UsersAppModel {
 						$postData[$this->alias]['role'] = 'admin';
 					}
 				}
-				$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
+				$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password']);
 				$this->create();
 				$result = $this->save($postData, false);
 				if ($result) {
@@ -860,7 +860,7 @@ class User extends UsersAppModel {
 			$this->set($postData);
 			if ($this->validates()) {
 				if(isset($postData[$this->alias]['password'])) {
-					$this->data[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
+					$this->data[$this->alias]['password'] = $this->hash($postData[$this->alias]['password']);
 				}
 				$result = $this->save(null, false);
 				if ($result) {

--- a/Model/User.php
+++ b/Model/User.php
@@ -574,7 +574,7 @@ class User extends UsersAppModel {
 
 		$this->set($postData);
 		if ($this->validates()) {
-			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);
+			$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
 			$this->create();
 			$this->data = $this->save($postData, false);
 			$this->data[$this->alias]['id'] = $this->id;
@@ -830,7 +830,7 @@ class User extends UsersAppModel {
 						$postData[$this->alias]['role'] = 'admin';
 					}
 				}
-				$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);
+				$postData[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
 				$this->create();
 				$result = $this->save($postData, false);
 				if ($result) {
@@ -860,7 +860,7 @@ class User extends UsersAppModel {
 			$this->set($postData);
 			if ($this->validates()) {
 				if(isset($postData[$this->alias]['password'])) {
-					$this->data[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], 'sha1', true);
+					$this->data[$this->alias]['password'] = $this->hash($postData[$this->alias]['password'], null, true);
 				}
 				$result = $this->save(null, false);
 				if ($result) {

--- a/Test/Case/Model/UserTest.php
+++ b/Test/Case/Model/UserTest.php
@@ -196,7 +196,7 @@ class UserTestCase extends CakeTestCase {
  * @return void
  */
 	public function testValidateOldPassword() {
-		$password = $this->User->hash('password', null, true);
+		$password = $this->User->hash('password');
 		$this->User->id = '1';
 		$this->User->saveField('password', $password);
 		$this->User->data = array(
@@ -289,7 +289,7 @@ class UserTestCase extends CakeTestCase {
 		$result = $this->User->data;
 
 		$this->assertEquals($result['User']['active'], 1);
-		$this->assertEquals($result['User']['password'], $this->User->hash('password', 'sha1', true));
+		$this->assertEquals($result['User']['password'], $this->User->hash('password'));
 		$this->assertTrue(is_string($result['User']['email_token']));
 
 		$result = $this->User->findById($this->User->id);
@@ -329,7 +329,7 @@ class UserTestCase extends CakeTestCase {
 			'recursive' => -1,
 			'conditions' => array(
 				'User.id' => 1)));
-		$this->assertEquals($ressult['User']['password'], $this->User->hash('testtest', null, true));
+		$this->assertEquals($ressult['User']['password'], $this->User->hash('testtest'));
 	}
 
 /**
@@ -464,7 +464,7 @@ class UserTestCase extends CakeTestCase {
 
 		$result = $this->User->edit($userId, $data1);
 
-		$hashPassword = $this->User->hash($data1['User']['password'], 'sha1', true);
+		$hashPassword = $this->User->hash($data1['User']['password']);
 		$this->assertTrue($result);
 		$this->assertEquals($this->User->data['User']['password'], $hashPassword);
 

--- a/Test/Fixture/UserFixture.php
+++ b/Test/Fixture/UserFixture.php
@@ -188,7 +188,7 @@ class UserFixture extends CakeTestFixture {
 		parent::__construct();
 		$this->User = ClassRegistry::init('Users.User');
 		foreach ($this->records as &$record) {
-			$record['password'] = $this->User->hash($record['password'], null, true);
+			$record['password'] = $this->User->hash($record['password']);
 		}
 	}
 


### PR DESCRIPTION
The hashing-method is currently defined via the `$type` and `$salt` parameters in many different places throughout the code. This PR aims to bundle all the definition in one place: the User->hash() method. Users that want to use a different hashing function can easily override the hash()-method and will not have to override all the other methods calling hash(). 

(Granted, they don't have to override those other methods, if they choose to simply ignore the second and third parameters of User->hash(), but that would make for really ugly and slightly misleading code.)