### PR TITLE
Do not display Tos Checkbox when Tos.required is set to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor
+CakeUsersPlugin.iml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 /vendor
-*.iml
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor
-CakeUsersPlugin.iml
+*.iml
 .idea

--- a/src/Template/Users/register.ctp
+++ b/src/Template/Users/register.ctp
@@ -20,7 +20,9 @@
         echo $this->Form->input('password_confirm', ['type' => 'password']);
         echo $this->Form->input('first_name');
         echo $this->Form->input('last_name');
-        echo $this->Form->input('tos', ['type' => 'checkbox', 'label' => __d('Users', 'Accept TOS conditions?'), 'required' => true]);
+        if (Configure::read('Users.Tos.required')) {
+          echo $this->Form->input('tos', ['type' => 'checkbox', 'label' => __d('Users', 'Accept TOS conditions?'), 'required' => true]);
+        }
         echo $this->User->addReCaptcha();
         ?>
     </fieldset>


### PR DESCRIPTION
If the config Users.Tos.required is set to false, then do not display the Tos check box during registration.