### PR TITLE
AbstractMapper social login by google email validate

### DIFF
--- a/src/Auth/Social/Mapper/AbstractMapper.php
+++ b/src/Auth/Social/Mapper/AbstractMapper.php
@@ -71,7 +71,7 @@ abstract class AbstractMapper
      */
     protected function _validated()
     {
-        return !empty($this->_rawData[$this->_mapFields['email']]);
+        return !empty(Hash::get($this->_rawData, $this->_mapFields['email']));
     }
 
     /**


### PR DESCRIPTION
Social login by google, Users.validate/active fields are always false.

AbstractMapper.php the function _validated return false because email field is returned in a array. 
'emails' => [
(int) 0 => [
	'value' => '...@...'
]

And mapFields['email'] for google is emails.0.value, cant use !empty() for that.