### PR TITLE
Feature/validation messages fix

### DIFF
--- a/src/Controller/Traits/PasswordManagementTrait.php
+++ b/src/Controller/Traits/PasswordManagementTrait.php
@@ -48,12 +48,16 @@ trait PasswordManagementTrait
         if ($this->request->is('post')) {
             try {
                 $user = $this->getUsersTable()->patchEntity($user, $this->request->data(), ['validate' => 'passwordConfirm']);
-                $user = $this->getUsersTable()->changePassword($user);
-                if ($user) {
-                    $this->Flash->success(__d('Users', 'Password has been changed successfully'));
-                    return $this->redirect($redirect);
-                } else {
+                if ($user->errors()) {
                     $this->Flash->error(__d('Users', 'Password could not be changed'));
+                } else {
+                    $user = $this->getUsersTable()->changePassword($user);
+                    if ($user) {
+                        $this->Flash->success(__d('Users', 'Password has been changed successfully'));
+                        return $this->redirect($redirect);
+                    } else {
+                        $this->Flash->error(__d('Users', 'Password could not be changed'));
+                    }
                 }
             } catch (UserNotFoundException $exception) {
                 $this->Flash->error(__d('Users', 'User was not found'));

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -151,13 +151,13 @@ class UsersTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
-        $rules->add($rules->isUnique(['username']), [
+        $rules->add($rules->isUnique(['username']), '_isUnique', [
             'errorField' => 'username',
             'message' => __d('Users', 'Username already exists')
         ]);
 
         if ($this->isValidateEmail) {
-            $rules->add($rules->isUnique(['email']), [
+            $rules->add($rules->isUnique(['email']), '_isUnique', [
                 'errorField' => 'email',
                 'message' => __d('Users', 'Email already exists')
             ]);


### PR DESCRIPTION
Two fixes for validation messages on 3.1.x branch

**Issue 1**
On "users/changePassword" form, when the passwords do not match, no validation error is displayed on the form inputs.
**Fix**
Check for errors after patchEntity.

**Issue 2**
On "users/register" form, when trying to register another user with an already in use "email" or "username", two error messages are displayed per field, one from the "isUnique" method and another from the build rule.
Example of error array returned:
```
email => [
    '_isUnique' => 'This value is already in use'
    0 => 'Email already exists'
]
```
**Fix**
Overwrite the "isUnique" message giving the name "_isUnique" to the rule.
Example of new error array returned:
```
email => [
    '_isUnique' => 'Email already exists'
]
```