### PR TITLE
refs #update-auth-scope Added finder for auth since 'scope' is deprecated

### DIFF
--- a/Docs/Documentation/Configuration.md
+++ b/Docs/Documentation/Configuration.md
@@ -94,7 +94,7 @@ NOTE: SOME keys were hidden in this doc page, please refer to `vendor/cakedc/use
     'Auth' => [
         'authenticate' => [
             'all' => [
-                'scope' => ['active' => 1]
+                'finder' => 'auth',
             ],
             'CakeDC/Users.RememberMe',
             'Form',
@@ -139,7 +139,7 @@ Configure::write('Auth.authenticate.Form.fields.username', 'email');
 ```
 
 
-  
+
 
 Email Templates
 ---------------

--- a/Docs/Documentation/Configuration.md
+++ b/Docs/Documentation/Configuration.md
@@ -94,7 +94,7 @@ NOTE: SOME keys were hidden in this doc page, please refer to `vendor/cakedc/use
     'Auth' => [
         'authenticate' => [
             'all' => [
-                'finder' => 'auth',
+                'finder' => 'active',
             ],
             'CakeDC/Users.RememberMe',
             'Form',

--- a/config/users.php
+++ b/config/users.php
@@ -91,7 +91,7 @@ $config = [
         ],
         'authenticate' => [
             'all' => [
-                'finder' => 'auth',
+                'finder' => 'active',
             ],
             'CakeDC/Users.ApiKey',
             'CakeDC/Users.RememberMe',

--- a/config/users.php
+++ b/config/users.php
@@ -91,7 +91,7 @@ $config = [
         ],
         'authenticate' => [
             'all' => [
-                'scope' => ['active' => 1]
+                'finder' => 'auth',
             ],
             'CakeDC/Users.ApiKey',
             'CakeDC/Users.RememberMe',

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -11,9 +11,9 @@
 
 namespace CakeDC\Users\Model\Table;
 
+use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\ORM\Query;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -170,13 +170,13 @@ class UsersTable extends Table
     }
 
     /**
-     * Custom finder for Auth.authenticate
+     * Custom finder to filter active users
      *
      * @param Query $query Query object to modify
      * @param array $options Query options
      * @return Query
      */
-    public function findAuth(Query $query, array $options = [])
+    public function findActive(Query $query, array $options = [])
     {
         $query->where(["{$this->_alias}.active" => 1]);
         return $query;

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -13,6 +13,7 @@ namespace CakeDC\Users\Model\Table;
 
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\ORM\Query;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
@@ -166,5 +167,18 @@ class UsersTable extends Table
         }
 
         return $rules;
+    }
+
+    /**
+     * Custom finder for Auth.authenticate
+     *
+     * @param Query $query Query object to modify
+     * @param array $options Query options
+     * @return Query
+     */
+    public function findAuth(Query $query, array $options = [])
+    {
+        $query->where(["{$this->_alias}.active" => 1]);
+        return $query;
     }
 }

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -323,6 +323,5 @@ class UsersTableTest extends TestCase
         $this->assertCount(8, $actual);
         $this->assertCount(8, Hash::extract($actual, '{n}[active=1]'));
         $this->assertCount(0, Hash::extract($actual, '{n}[active=0]'));
-
     }
 }

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -20,8 +20,8 @@ use Cake\Mailer\Email;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use Cake\Utility\Hash;
+use InvalidArgumentException;
 
 /**
  * Users\Model\Table\UsersTable Test Case

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -314,12 +314,12 @@ class UsersTableTest extends TestCase
     }
 
     /**
-     * Test findAuth method.
+     * Test findActive method.
      *
      */
-    public function testFindAuth()
+    public function testFindActive()
     {
-        $actual = $this->Users->find('auth')->toArray();
+        $actual = $this->Users->find('active')->toArray();
         $this->assertCount(8, $actual);
         $this->assertCount(8, Hash::extract($actual, '{n}[active=1]'));
         $this->assertCount(0, Hash::extract($actual, '{n}[active=0]'));

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Cake\Utility\Hash;
 
 /**
  * Users\Model\Table\UsersTable Test Case
@@ -310,5 +311,18 @@ class UsersTableTest extends TestCase
         $this->assertEquals('username', $result->username);
         $this->assertEquals('First Name', $result->first_name);
         $this->assertEquals('Last Name', $result->last_name);
+    }
+
+    /**
+     * Test findAuth method.
+     *
+     */
+    public function testFindAuth()
+    {
+        $actual = $this->Users->find('auth')->toArray();
+        $this->assertCount(8, $actual);
+        $this->assertCount(8, Hash::extract($actual, '{n}[active=1]'));
+        $this->assertCount(0, Hash::extract($actual, '{n}[active=0]'));
+
     }
 }


### PR DESCRIPTION
Added a custom finder for Auth configuration, as 'scope' has been deprecated since 3.1.

http://book.cakephp.org/3.0/en/controllers/components/authentication.html#customizing-find-query