### PR TITLE
Refs #306 ensuring user is active when trying to reset password

### DIFF
--- a/src/Controller/Traits/PasswordManagementTrait.php
+++ b/src/Controller/Traits/PasswordManagementTrait.php
@@ -11,8 +11,8 @@
 
 namespace CakeDC\Users\Controller\Traits;
 
-use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\UserNotActiveException;
+use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use Cake\Core\Configure;
 use Exception;

--- a/src/Controller/Traits/PasswordManagementTrait.php
+++ b/src/Controller/Traits/PasswordManagementTrait.php
@@ -12,6 +12,7 @@
 namespace CakeDC\Users\Controller\Traits;
 
 use CakeDC\Users\Exception\UserNotFoundException;
+use CakeDC\Users\Exception\UserNotActiveException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use Cake\Core\Configure;
 use Exception;
@@ -101,6 +102,7 @@ trait PasswordManagementTrait
                 'expiration' => Configure::read('Users.Token.expiration'),
                 'checkActive' => false,
                 'sendEmail' => true,
+                'ensureActive' => true
             ]);
             if ($resetUser) {
                 $msg = __d('Users', 'Please check your email to continue with password reset process');
@@ -112,6 +114,8 @@ trait PasswordManagementTrait
             return $this->redirect(['action' => 'login']);
         } catch (UserNotFoundException $exception) {
             $this->Flash->error(__d('Users', 'User {0} was not found', $reference));
+        } catch (UserNotActiveException $exception) {
+            $this->Flash->error(__d('Users', 'The user is not active'));
         } catch (Exception $exception) {
             $this->Flash->error(__d('Users', 'Token could not be reset'));
         }

--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -14,6 +14,7 @@ namespace CakeDC\Users\Model\Behavior;
 use CakeDC\Users\Email\EmailSender;
 use CakeDC\Users\Exception\UserAlreadyActiveException;
 use CakeDC\Users\Exception\UserNotFoundException;
+use CakeDC\Users\Exception\UserNotActiveException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use CakeDC\Users\Model\Behavior\Behavior;
 use Cake\Datasource\EntityInterface;
@@ -70,6 +71,11 @@ class PasswordBehavior extends Behavior
             }
             $user->active = false;
             $user->activation_date = null;
+        }
+        if (Hash::Get($options, 'ensureActive')) {
+            if (!$user->active) {
+                throw new UserNotActiveException("User not active");
+            }
         }
         $user->updateToken($expiration);
         $saveResult = $this->_table->save($user);

--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -18,6 +18,7 @@ use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use CakeDC\Users\Model\Behavior\Behavior;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Mailer\Email;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
@@ -106,9 +107,13 @@ class PasswordBehavior extends Behavior
      */
     public function changePassword(EntityInterface $user)
     {
-        $currentUser = $this->_table->get($user->id, [
-            'contain' => []
-        ]);
+        try {
+            $currentUser = $this->_table->get($user->id, [
+                'contain' => []
+            ]);
+        } catch (RecordNotFoundException $e) {
+            throw new UserNotFoundException(__d('Users', "User not found"));
+        }
 
         if (!empty($user->current_password)) {
             if (!$user->checkPassword($user->current_password, $currentUser->password)) {

--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -13,8 +13,8 @@ namespace CakeDC\Users\Model\Behavior;
 
 use CakeDC\Users\Email\EmailSender;
 use CakeDC\Users\Exception\UserAlreadyActiveException;
-use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\UserNotActiveException;
+use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use CakeDC\Users\Model\Behavior\Behavior;
 use Cake\Datasource\EntityInterface;

--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -67,14 +67,14 @@ class PasswordBehavior extends Behavior
         }
         if (Hash::get($options, 'checkActive')) {
             if ($user->active) {
-                throw new UserAlreadyActiveException("User account already validated");
+                throw new UserAlreadyActiveException(__d('Users', "User account already validated"));
             }
             $user->active = false;
             $user->activation_date = null;
         }
-        if (Hash::Get($options, 'ensureActive')) {
+        if (Hash::get($options, 'ensureActive')) {
             if (!$user->active) {
-                throw new UserNotActiveException("User not active");
+                throw new UserNotActiveException(__d('Users', "User not active"));
             }
         }
         $user->updateToken($expiration);

--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -73,7 +73,7 @@ class PasswordBehavior extends Behavior
             $user->activation_date = null;
         }
         if (Hash::get($options, 'ensureActive')) {
-            if (!$user->active) {
+            if (!$user['active']) {
                 throw new UserNotActiveException(__d('Users', "User not active"));
             }
         }

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -185,21 +185,4 @@ abstract class BaseTraitTest extends TestCase
                 ->method('dispatchEvent')
                 ->will($this->returnValue($event));
     }
-
-    /**
-     * Config email
-     *
-     * @return void
-     */
-    protected function _configEmail()
-    {
-        \Cake\Mailer\Email::configTransport('default', [
-            'className' => 'Debug'
-        ]);
-        \Cake\Mailer\Email::config('default', [
-            'transport' => 'default',
-            'from' => 'test@test.com',
-            'log' => true
-        ]);
-    }
 }

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -138,7 +138,7 @@ abstract class BaseTraitTest extends TestCase
      *
      * @return void
      */
-    protected function _mockAuthLoggedIn($user = array())
+    protected function _mockAuthLoggedIn($user = [])
     {
         $this->Trait->Auth = $this->getMockBuilder('Cake\Controller\Component\AuthComponent')
             ->setMethods(['user', 'identify', 'setUser', 'redirectUrl'])

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -185,4 +185,21 @@ abstract class BaseTraitTest extends TestCase
                 ->method('dispatchEvent')
                 ->will($this->returnValue($event));
     }
+
+    /**
+     * Config email
+     *
+     * @return void
+     */
+    protected function _configEmail()
+    {
+        \Cake\Mailer\Email::configTransport('default', [
+            'className' => 'Debug'
+        ]);
+        \Cake\Mailer\Email::config('default', [
+            'transport' => 'default',
+            'from' => 'test@test.com',
+            'log' => true
+        ]);
+    }
 }

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -138,13 +138,13 @@ abstract class BaseTraitTest extends TestCase
      *
      * @return void
      */
-    protected function _mockAuthLoggedIn()
+    protected function _mockAuthLoggedIn($user = array())
     {
         $this->Trait->Auth = $this->getMockBuilder('Cake\Controller\Component\AuthComponent')
             ->setMethods(['user', 'identify', 'setUser', 'redirectUrl'])
             ->disableOriginalConstructor()
             ->getMock();
-        $user = [
+        $user += [
             'id' => '00000000-0000-0000-0000-000000000001',
             'password' => '12345',
         ];
@@ -154,7 +154,7 @@ abstract class BaseTraitTest extends TestCase
         $this->Trait->Auth->expects($this->any())
             ->method('user')
             ->with('id')
-            ->will($this->returnValue('00000000-0000-0000-0000-000000000001'));
+            ->will($this->returnValue($user['id']));
     }
 
     /**

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -142,20 +142,21 @@ class PasswordManagementTraitTest extends BaseTraitTest
      */
     public function testRequestPasswordHappy()
     {
-        $this->assertEquals('ae93ddbe32664ce7927cf0c5c5a5e59d', $this->table->get('00000000-0000-0000-0000-000000000001')->token);
+        $this->assertEquals('6614f65816754310a5f0553436dd89e9', $this->table->get('00000000-0000-0000-0000-000000000002')->token);
         $this->_mockRequestPost();
         $this->_mockAuthLoggedIn();
         $this->_mockFlash();
-        $reference = 'user-1';
+        $this->_configEmail();
+        $reference = 'user-2';
         $this->Trait->request->expects($this->once())
                 ->method('data')
                 ->with('reference')
                 ->will($this->returnValue($reference));
         $this->Trait->Flash->expects($this->any())
             ->method('success')
-            ->with('Password has been changed successfully');
+            ->with('Please check your email to continue with password reset process');
         $this->Trait->requestResetPassword();
-        $this->assertNotEquals('xxx', $this->table->get('00000000-0000-0000-0000-000000000001')->token);
+        $this->assertNotEquals('xxx', $this->table->get('00000000-0000-0000-0000-000000000002')->token);
     }
 
     /**

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -27,6 +27,7 @@ class PasswordManagementTraitTest extends BaseTraitTest
     {
         $this->traitClassName = 'CakeDC\Users\Controller\Traits\PasswordManagementTrait';
         $this->traitMockMethods = ['set', 'redirect', 'validate'];
+        $this->mockDefaultEmail = true;
         parent::setUp();
     }
 
@@ -146,7 +147,6 @@ class PasswordManagementTraitTest extends BaseTraitTest
         $this->_mockRequestPost();
         $this->_mockAuthLoggedIn();
         $this->_mockFlash();
-        $this->_configEmail();
         $reference = 'user-2';
         $this->Trait->request->expects($this->once())
                 ->method('data')

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -157,4 +157,26 @@ class PasswordManagementTraitTest extends BaseTraitTest
         $this->Trait->requestResetPassword();
         $this->assertNotEquals('xxx', $this->table->get('00000000-0000-0000-0000-000000000001')->token);
     }
+
+    /**
+     * test requestResetPassword
+     *
+     * @return void
+     */
+    public function testRequestResetPasswordUserNotActive()
+    {
+        $this->assertEquals('ae93ddbe32664ce7927cf0c5c5a5e59d', $this->table->get('00000000-0000-0000-0000-000000000001')->token);
+        $this->_mockRequestPost();
+        $this->_mockFlash();
+        $reference = 'user-1';
+        $this->Trait->request->expects($this->once())
+                ->method('data')
+                ->with('reference')
+                ->will($this->returnValue($reference));
+        $this->Trait->Flash->expects($this->any())
+            ->method('error')
+            ->with('The user is not active');
+        $this->Trait->requestResetPassword();
+        $this->assertNotEquals('xxx', $this->table->get('00000000-0000-0000-0000-000000000001')->token);
+    }
 }

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -74,6 +74,51 @@ class PasswordManagementTraitTest extends BaseTraitTest
      *
      * @return void
      */
+    public function testChangePasswordWithError()
+    {
+        $this->assertEquals('12345', $this->table->get('00000000-0000-0000-0000-000000000001')->password);
+        $this->_mockRequestPost();
+        $this->_mockAuthLoggedIn();
+        $this->_mockFlash();
+        $this->Trait->request->expects($this->once())
+                ->method('data')
+                ->will($this->returnValue([
+                    'password' => 'new',
+                    'password_confirm' => 'wrong_new',
+                ]));
+        $this->Trait->Flash->expects($this->once())
+            ->method('error')
+            ->with('Password could not be changed');
+        $this->Trait->changePassword();
+    }
+
+    /**
+     * test
+     *
+     * @return void
+     */
+    public function testChangePasswordWithInvalidUser()
+    {
+        $this->_mockRequestPost();
+        $this->_mockAuthLoggedIn(['id' => 'invalid-id', 'password' => 'invalid-pass']);
+        $this->_mockFlash();
+        $this->Trait->request->expects($this->once())
+                ->method('data')
+                ->will($this->returnValue([
+                    'password' => 'new',
+                    'password_confirm' => 'new',
+                ]));
+        $this->Trait->Flash->expects($this->once())
+            ->method('error')
+            ->with('User was not found');
+        $this->Trait->changePassword();
+    }
+
+    /**
+     * test
+     *
+     * @return void
+     */
     public function testChangePasswordGetLoggedIn()
     {
         $this->_mockRequestGet();
@@ -157,6 +202,48 @@ class PasswordManagementTraitTest extends BaseTraitTest
             ->with('Please check your email to continue with password reset process');
         $this->Trait->requestResetPassword();
         $this->assertNotEquals('xxx', $this->table->get('00000000-0000-0000-0000-000000000002')->token);
+    }
+
+    /**
+     * test
+     *
+     * @return void
+     */
+    public function testRequestPasswordInvalidUser()
+    {
+        $this->_mockRequestPost();
+        $this->_mockAuthLoggedIn(['id' => 'invalid-id', 'password' => 'invalid-pass']);
+        $this->_mockFlash();
+        $reference = 'invalid-id';
+        $this->Trait->request->expects($this->once())
+                ->method('data')
+                ->with('reference')
+                ->will($this->returnValue($reference));
+        $this->Trait->Flash->expects($this->any())
+            ->method('error')
+            ->with('User invalid-id was not found');
+        $this->Trait->requestResetPassword();
+    }
+
+    /**
+     * test
+     *
+     * @return void
+     */
+    public function testRequestPasswordEmptyReference()
+    {
+        $this->_mockRequestPost();
+        $this->_mockAuthLoggedIn(['id' => 'invalid-id', 'password' => 'invalid-pass']);
+        $this->_mockFlash();
+        $reference = '';
+        $this->Trait->request->expects($this->once())
+                ->method('data')
+                ->with('reference')
+                ->will($this->returnValue($reference));
+        $this->Trait->Flash->expects($this->any())
+            ->method('error')
+            ->with('Token could not be reset');
+        $this->Trait->requestResetPassword();
     }
 
     /**

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -100,7 +100,7 @@ class PasswordManagementTraitTest extends BaseTraitTest
     public function testChangePasswordWithInvalidUser()
     {
         $this->_mockRequestPost();
-        $this->_mockAuthLoggedIn(['id' => 'invalid-id', 'password' => 'invalid-pass']);
+        $this->_mockAuthLoggedIn(['id' => '12312312-0000-0000-0000-000000000002', 'password' => 'invalid-pass']);
         $this->_mockFlash();
         $this->Trait->request->expects($this->once())
                 ->method('data')
@@ -214,14 +214,14 @@ class PasswordManagementTraitTest extends BaseTraitTest
         $this->_mockRequestPost();
         $this->_mockAuthLoggedIn(['id' => 'invalid-id', 'password' => 'invalid-pass']);
         $this->_mockFlash();
-        $reference = 'invalid-id';
+        $reference = '12312312-0000-0000-0000-000000000002';
         $this->Trait->request->expects($this->once())
                 ->method('data')
                 ->with('reference')
                 ->will($this->returnValue($reference));
         $this->Trait->Flash->expects($this->any())
             ->method('error')
-            ->with('User invalid-id was not found');
+            ->with('User 12312312-0000-0000-0000-000000000002 was not found');
         $this->Trait->requestResetPassword();
     }
 

--- a/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
@@ -146,4 +146,18 @@ class PasswordBehaviorTest extends TestCase
             'checkActive' => true,
         ]);
     }
+
+    /**
+     * Test resetToken
+     *
+     * @expectedException CakeDC\Users\Exception\UserNotActiveException
+     */
+    public function testResetTokenUserNotActive()
+    {
+        $user = TableRegistry::get('CakeDC/Users.Users')->findAllByUsername('user-1')->first();
+        $this->Behavior->resetToken('user-1', [
+            'ensureActive' => true,
+            'expiration' => 3600
+        ]);
+    }
 }


### PR DESCRIPTION
It fixes the #306 

I've added one more option, `ensureActive`, to `PasswordBehavior#resetToken`.

Then `PasswordManagementTrait#requestResetPassword` passes the option when calling the `PasswordBehavior#resetToken`.

Sounds enough?