### PR TITLE
optional method for controlling public access

### DIFF
--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -146,6 +146,45 @@ class UsersAuthComponent extends Component
     }
 
     /**
+     * Check Public Access
+     *
+     * ### Usage
+     * Add this to your AppController
+     * ```php
+     * public function beforeFilter(Event $event) {
+     *     $this->UsersAuth->isPublicAuthorized($event);
+     * }
+     * ```
+     *
+     * Your permssions config should return '*' or 'public' for role allowed.
+     *
+     * Ex. In permissions.php for SimpleRbacAuthorize
+     * ```php
+     * 'Users.SimpleRbac.permissions' => [
+     *     [
+     *         'role' => '*',
+     *         'controller' => ['Pages'],
+     *         'action' => ['other', 'display'],
+     *         'allowed' => true,
+     *     ]];
+     *
+     * @param Event $event
+     * @return bool
+     */
+    public function isPublicAuthorized(Event $event)
+    {
+        $isAuthorized = null;
+        if (empty($this->_registry->getController()->Auth->user())) {
+            $controller = $event->subject();
+            $isAuthorized = $this->_registry->getController()->Auth->isAuthorized(['role' => 'public'], $controller->request);
+            if ($isAuthorized === true) {
+                $this->_registry->getController()->Auth->allow();
+            }
+        }
+        return $isAuthorized;
+    }
+
+    /**
      * Validate if the passed configuration makes sense
      *
      * @throws BadConfigurationException


### PR DESCRIPTION
Please see the usage notes in the comments to see how this is a new *optional* method allows users to control public or guest access from the permissions.php config file.  The benefit is that it allows all permissions to be controlled from a single place - including public permissions, as opposed to having some permissions in the individual controllers (eg. $this->Auth->allow('someAction')) and some permissions in the config file.