### PR TITLE
new public access control method

### DIFF
--- a/Docs/Documentation/Configuration.md
+++ b/Docs/Documentation/Configuration.md
@@ -63,6 +63,8 @@ NOTE: SOME keys were hidden in this doc page, please refer to `vendor/cakedc/use
         'table' => 'CakeDC/Users.Users',
         //configure Auth component
         'auth' => true,
+        //Public access control
+        'publicAcl' => false,
         'Email' => [
             //determines if the user should include email
             'required' => true,

--- a/config/users.php
+++ b/config/users.php
@@ -20,6 +20,8 @@ $config = [
         'auth' => true,
         //Password Hasher
         'passwordHasher' => '\Cake\Auth\DefaultPasswordHasher',
+        //Manage public permissions
+        'publicControl' => false,
         //token expiration, 1 hour
         'Token' => ['expiration' => 3600],
         'Email' => [

--- a/config/users.php
+++ b/config/users.php
@@ -21,7 +21,7 @@ $config = [
         //Password Hasher
         'passwordHasher' => '\Cake\Auth\DefaultPasswordHasher',
         //Manage public permissions
-        'publicControl' => false,
+        'publicAcl' => false,
         //token expiration, 1 hour
         'Token' => ['expiration' => 3600],
         'Email' => [

--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -52,6 +52,10 @@ class UsersAuthComponent extends Component
         }
 
         $this->_attachPermissionChecker();
+        
+        if (Configure::read('Users.publicAcl')) {
+            $this->isPublicAuthorized();
+        }
     }
 
     /**
@@ -111,6 +115,38 @@ class UsersAuthComponent extends Component
             'endpoint',
             'authenticated'
         ]);
+    }
+
+    /**
+     * Check Public Access
+     *
+     * ### Usage
+     *
+     * Your permssions config should return '*' or 'public' for role(s) allowed.
+     *
+     * Ex. In permissions.php for SimpleRbacAuthorize
+     * ```php
+     * 'Users.SimpleRbac.permissions' => [
+     *     [
+     *         'role' => '*',
+     *         'controller' => ['Pages'],
+     *         'action' => ['other', 'display'],
+     *         'allowed' => true,
+     *     ]];
+     *
+     * @return bool
+     */
+    public function isPublicAuthorized()
+    {
+        $isAuthorized = null;
+        if (empty($this->_registry->getController()->Auth->user())) {
+            $controller = $this->_registry->getController();
+            $isAuthorized = $controller->Auth->isAuthorized(['role' => 'public'], $controller->request);
+            if ($isAuthorized === true) {
+                $this->_registry->getController()->Auth->allow();
+            }
+        }
+        return $isAuthorized;
     }
 
     /**

--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -139,11 +139,11 @@ class UsersAuthComponent extends Component
     public function isPublicAuthorized()
     {
         $isAuthorized = null;
-        if (empty($this->_registry->getController()->Auth->user())) {
-            $controller = $this->_registry->getController();
+        $controller = $this->_registry->getController();
+        if (empty($controller->Auth->user())) {
             $isAuthorized = $controller->Auth->isAuthorized(['role' => 'public'], $controller->request);
             if ($isAuthorized === true) {
-                $this->_registry->getController()->Auth->allow();
+                $controller->Auth->allow();
             }
         }
         return $isAuthorized;


### PR DESCRIPTION
This is an update to this pull request : https://github.com/CakeDC/users/pull/332#issuecomment-200078664.  Please note, that I opted not to add the new config var "public => true", as was suggested, because by keeping it within the role variable this is usable beyond just the SimpleRbac config.  Instead I added a new config var to users.php to turn public access control on or off, that way it won't effect current users.  Please review. 