### PR TITLE
refs #374 Add not empty validation for current_password

### DIFF
--- a/src/Controller/Traits/PasswordManagementTrait.php
+++ b/src/Controller/Traits/PasswordManagementTrait.php
@@ -15,6 +15,7 @@ use CakeDC\Users\Exception\UserNotActiveException;
 use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Exception\WrongPasswordException;
 use Cake\Core\Configure;
+use Cake\Validation\Validator;
 use Exception;
 
 /**
@@ -48,7 +49,11 @@ trait PasswordManagementTrait
         $this->set('validatePassword', $validatePassword);
         if ($this->request->is('post')) {
             try {
-                $user = $this->getUsersTable()->patchEntity($user, $this->request->data(), ['validate' => 'passwordConfirm']);
+                $validator = $this->getUsersTable()->validationPasswordConfirm(new Validator());
+                if (!empty($id)) {
+                    $validator = $this->getUsersTable()->validationCurrentPassword($validator);
+                }
+                $user = $this->getUsersTable()->patchEntity($user, $this->request->data(), ['validate' => $validator]);
                 if ($user->errors()) {
                     $this->Flash->error(__d('Users', 'Password could not be changed'));
                 } else {

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -87,6 +87,20 @@ class UsersTable extends Table
     }
 
     /**
+     * Adds rules for current password
+     *
+     * @param Validator $validator Cake validator object.
+     * @return Validator
+     */
+    public function validationCurrentPassword(Validator $validator)
+    {
+        $validator
+            ->notEmpty('current_password');
+
+        return $validator;
+    }
+
+    /**
      * Default validation rules.
      *
      * @param Validator $validator Validator instance.

--- a/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
+++ b/tests/TestCase/Controller/Traits/PasswordManagementTraitTest.php
@@ -124,6 +124,29 @@ class PasswordManagementTraitTest extends BaseTraitTest
      *
      * @return void
      */
+    public function testChangePasswordWithEmptyCurrentPassword()
+    {
+        $this->_mockRequestPost();
+        $this->_mockAuthLoggedIn(['id' => '00000000-0000-0000-0000-000000000006', 'password' => '$2y$10$IPPgJNSfvATsMBLbv/2r8OtpyTBibyM1g5GDxD4PivW9qBRwRkRbC']);
+        $this->_mockFlash();
+        $this->Trait->request->expects($this->once())
+            ->method('data')
+            ->will($this->returnValue([
+                'current_password' => '',
+                'password' => '54321',
+                'password_confirm' => '54321',
+            ]));
+        $this->Trait->Flash->expects($this->once())
+            ->method('error')
+            ->with('Password could not be changed');
+        $this->Trait->changePassword();
+    }
+
+    /**
+     * test
+     *
+     * @return void
+     */
     public function testChangePasswordWithWrongCurrentPassword()
     {
         $this->assertEquals(


### PR DESCRIPTION
Refs  #374

Add not empty validation for current_password field when a logged in user try to change his password.