### PR TITLE
refs #381 update deprecated methods from phpunit

### DIFF
--- a/tests/TestCase/Auth/ApiKeyAuthenticateTest.php
+++ b/tests/TestCase/Auth/ApiKeyAuthenticateTest.php
@@ -38,11 +38,10 @@ class ApiKeyAuthenticateTest extends TestCase
         $request = new Request();
         $response = new Response();
 
-        $controller = $this->getMock(
-            'Cake\Controller\Controller',
-            null,
-            [$request, $response]
-        );
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(null)
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
         $registry = new ComponentRegistry($controller);
         $this->apiKey = new ApiKeyAuthenticate($registry, ['require_ssl' => false]);
     }

--- a/tests/TestCase/Auth/RememberMeAuthenticateTest.php
+++ b/tests/TestCase/Auth/RememberMeAuthenticateTest.php
@@ -41,11 +41,10 @@ class RememberMeAuthenticateTest extends TestCase
         $request = new Request();
         $response = new Response();
 
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            null,
-            [$request, $response]
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(null)
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
         $registry = new ComponentRegistry($this->controller);
         $this->rememberMe = new RememberMeAuthenticate($registry);
     }

--- a/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
+++ b/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
@@ -63,11 +63,10 @@ class SimpleRbacAuthorizeTest extends TestCase
         $request = new Request();
         $response = new Response();
 
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            null,
-            [$request, $response]
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(null)
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
         $this->registry = new ComponentRegistry($this->controller);
     }
 
@@ -112,11 +111,10 @@ class SimpleRbacAuthorizeTest extends TestCase
      */
     public function testConstructMissingPermissionsFile()
     {
-        $this->simpleRbacAuthorize = $this->getMock(
-            'CakeDC\Users\Auth\SimpleRbacAuthorize',
-            null,
-            [$this->registry, ['autoload_config' => 'does-not-exist']]
-        );
+        $this->simpleRbacAuthorize = $this->getMockBuilder('CakeDC\Users\Auth\SimpleRbacAuthorize')
+            ->setMethods(null)
+            ->setConstructorArgs([$this->registry, ['autoload_config' => 'does-not-exist']])
+            ->getMock();
         //we should have the default permissions
         $this->assertEquals($this->defaultPermissions, $this->simpleRbacAuthorize->config('permissions'));
     }

--- a/tests/TestCase/Auth/SocialAuthenticateTest.php
+++ b/tests/TestCase/Auth/SocialAuthenticateTest.php
@@ -50,11 +50,10 @@ class SocialAuthenticateTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['failedSocialLogin'],
-            [$request, $response]
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['failedSocialLogin'])
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
 
         $this->Request = $request;
         $this->SocialAuthenticate = $this->_getSocialAuthenticateMockMethods(['_authenticate', '_getProviderName',
@@ -178,7 +177,9 @@ class SocialAuthenticateTest extends TestCase
         $this->SocialAuthenticate = $this->_getSocialAuthenticateMockMethods(['_authenticate',
                 '_getProviderName', '_mapUser', '_touch', '_validateConfig' ]);
 
-        $session = $this->getMock('Cake\Network\Session', ['read', 'delete']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['read', 'delete'])
+                ->getMock();
         $session->expects($this->once())
             ->method('read')
             ->with('Users.social')
@@ -188,7 +189,9 @@ class SocialAuthenticateTest extends TestCase
             ->method('delete')
             ->with('Users.social');
 
-        $this->Request = $this->getMock('Cake\Network\Request', ['session']);
+        $this->Request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session'])
+                ->getMock();
         $this->Request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));

--- a/tests/TestCase/Auth/SuperuserAuthorizeTest.php
+++ b/tests/TestCase/Auth/SuperuserAuthorizeTest.php
@@ -36,11 +36,10 @@ class SuperuserAuthorizeTest extends TestCase
         $request = new Request();
         $response = new Response();
 
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            null,
-            [$request, $response]
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(null)
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
         $registry = new ComponentRegistry($this->controller);
         $this->superuserAuthorize = new SuperuserAuthorize($registry);
     }

--- a/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
@@ -177,6 +177,7 @@ class UsersAuthComponentTest extends TestCase
             'controller' => 'Users',
             'action' => 'requestResetPassword',
             'pass' => [],
+            '_matchedRoute' => '/route/*',
         ];
         $this->Controller->Auth->expects($this->once())
                 ->method('isAuthorized')
@@ -215,6 +216,7 @@ class UsersAuthComponentTest extends TestCase
             'controller' => 'Users',
             'action' => 'requestResetPassword',
             'pass' => ['pass-one'],
+            '_matchedRoute' => '/route/*',
         ];
         $this->Controller->Auth->expects($this->once())
                 ->method('isAuthorized')

--- a/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
@@ -59,9 +59,13 @@ class UsersAuthComponentTest extends TestCase
         ]);
         Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
         Configure::write('App.namespace', 'Users');
-        $this->request = $this->getMock('Cake\Network\Request', ['is', 'method']);
+        $this->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['is', 'method'])
+                ->getMock();
         $this->request->expects($this->any())->method('is')->will($this->returnValue(true));
-        $this->response = $this->getMock('Cake\Network\Response', ['stop']);
+        $this->response = $this->getMockBuilder('Cake\Network\Response')
+                ->setMethods(['stop'])
+                ->getMock();
         $this->Controller = new Controller($this->request, $this->response);
         $this->Registry = $this->Controller->components();
         $this->Controller->UsersAuth = new UsersAuthComponent($this->Registry);

--- a/tests/TestCase/Controller/Traits/CustomUsersTableTraitTest.php
+++ b/tests/TestCase/Controller/Traits/CustomUsersTableTraitTest.php
@@ -19,10 +19,9 @@ class CustomUsersTableTraitTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['header', 'redirect', 'render', '_stop']
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+                ->setMethods(['header', 'redirect', 'render', '_stop'])
+                ->getMock();
         $this->controller->Trait = $this->getMockForTrait('CakeDC\Users\Controller\Traits\CustomUsersTableTrait');
     }
 

--- a/tests/TestCase/Controller/Traits/RecaptchaTraitTest.php
+++ b/tests/TestCase/Controller/Traits/RecaptchaTraitTest.php
@@ -45,8 +45,14 @@ class ReCaptchaTraitTest extends TestCase
      */
     public function testValidateValidReCaptcha()
     {
-        $ReCaptcha = $this->getMock('ReCaptcha\ReCaptcha', ['verify'], [], '', false);
-        $Response = $this->getMock('ReCaptcha\Response', ['isSuccess'], [], '', false);
+        $ReCaptcha = $this->getMockBuilder('ReCaptcha\ReCaptcha')
+                ->setMethods(['verify'])
+                ->disableOriginalConstructor()
+                ->getMock();
+        $Response = $this->getMockBuilder('ReCaptcha\Response')
+                ->setMethods(['isSuccess'])
+                ->disableOriginalConstructor()
+                ->getMock();
         $Response->expects($this->any())
             ->method('isSuccess')
             ->will($this->returnValue(true));
@@ -67,8 +73,14 @@ class ReCaptchaTraitTest extends TestCase
      */
     public function testValidateInvalidReCaptcha()
     {
-        $ReCaptcha = $this->getMock('ReCaptcha\ReCaptcha', ['verify'], [], '', false);
-        $Response = $this->getMock('ReCaptcha\Response', ['isSuccess'], [], '', false);
+        $ReCaptcha = $this->getMockBuilder('ReCaptcha\ReCaptcha')
+                ->setMethods(['verify'])
+                ->disableOriginalConstructor()
+                ->getMock();
+        $Response = $this->getMockBuilder('ReCaptcha\Response')
+                ->setMethods(['isSuccess'])
+                ->disableOriginalConstructor()
+                ->getMock();
         $Response->expects($this->any())
             ->method('isSuccess')
             ->will($this->returnValue(false));

--- a/tests/TestCase/Controller/Traits/SocialTraitTest.php
+++ b/tests/TestCase/Controller/Traits/SocialTraitTest.php
@@ -19,10 +19,10 @@ class SocialTraitTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['header', 'redirect', 'render', '_stop']
-        );
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['header', 'redirect', 'render', '_stop'])
+            ->getMock();
+
         $this->controller->Trait = $this->getMockForTrait(
             'CakeDC\Users\Controller\Traits\SocialTrait',
             [],
@@ -45,7 +45,9 @@ class SocialTraitTest extends TestCase
      */
     public function testSocialEmail()
     {
-        $session = $this->getMock('Cake\Network\Session', ['check', 'delete']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['check', 'delete'])
+                ->getMock();
         $session->expects($this->at(0))
             ->method('check')
             ->with('Users.social')
@@ -55,7 +57,9 @@ class SocialTraitTest extends TestCase
             ->method('delete')
             ->with('Flash.auth');
 
-        $this->controller->Trait->request = $this->getMock('Cake\Network\Request', ['session']);
+        $this->controller->Trait->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session'])
+                ->getMock();
         $this->controller->Trait->request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));
@@ -70,13 +74,17 @@ class SocialTraitTest extends TestCase
      */
     public function testSocialEmailInvalid()
     {
-        $session = $this->getMock('Cake\Network\Session', ['check']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['check'])
+                ->getMock();
         $session->expects($this->once())
             ->method('check')
             ->with('Users.social')
             ->will($this->returnValue(null));
 
-        $this->controller->Trait->request = $this->getMock('Cake\Network\Request', ['session']);
+        $this->controller->Trait->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session'])
+                ->getMock();
         $this->controller->Trait->request->expects($this->once())
             ->method('session')
             ->will($this->returnValue($session));
@@ -86,7 +94,9 @@ class SocialTraitTest extends TestCase
 
     public function testSocialEmailPostValidateFalse()
     {
-        $session = $this->getMock('Cake\Network\Session', ['check', 'delete']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['check', 'delete'])
+                ->getMock();
         $session->expects($this->any())
             ->method('check')
             ->with('Users.social')
@@ -96,7 +106,9 @@ class SocialTraitTest extends TestCase
             ->method('delete')
             ->with('Flash.auth');
 
-        $this->controller->Trait->request = $this->getMock('Cake\Network\Request', ['session', 'is']);
+        $this->controller->Trait->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session', 'is'])
+                ->getMock();
         $this->controller->Trait->request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));
@@ -124,7 +136,9 @@ class SocialTraitTest extends TestCase
 
     public function testSocialEmailPostValidateTrue()
     {
-        $session = $this->getMock('Cake\Network\Session', ['check', 'delete']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['check', 'delete'])
+                ->getMock();
         $session->expects($this->any())
             ->method('check')
             ->with('Users.social')
@@ -134,7 +148,9 @@ class SocialTraitTest extends TestCase
             ->method('delete')
             ->with('Flash.auth');
 
-        $this->controller->Trait->request = $this->getMock('Cake\Network\Request', ['session', 'is']);
+        $this->controller->Trait->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session', 'is'])
+                ->getMock();
         $this->controller->Trait->request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));

--- a/tests/TestCase/Shell/UsersShellTest.php
+++ b/tests/TestCase/Shell/UsersShellTest.php
@@ -38,7 +38,7 @@ class UsersShellTest extends TestCase
     {
         parent::setUp();
         $this->out = new ConsoleOutput();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->Users = TableRegistry::get('CakeDC/Users.Users');
 
         $this->Shell = $this->getMockBuilder('CakeDC\Users\Shell\UsersShell')
@@ -51,11 +51,10 @@ class UsersShellTest extends TestCase
             ->setMethods(['generateUniqueUsername', 'newEntity', 'save', 'updateAll'])
             ->getMock();
 
-        $this->Shell->Command = $this->getMock(
-            'Cake\Shell\Task\CommandTask',
-            ['in', '_stop', 'clear', 'out'],
-            [$this->io]
-        );
+        $this->Shell->Command = $this->getMockBuilder('Cake\Shell\Task\CommandTask')
+            ->setMethods(['in', '_stop', 'clear', 'out'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Helper/UserHelperTest.php
+++ b/tests/TestCase/View/Helper/UserHelperTest.php
@@ -36,7 +36,9 @@ class UserHelperTest extends TestCase
     {
         parent::setUp();
         Plugin::routes('CakeDC/Users');
-        $this->View = $this->getMock('Cake\View\View', ['append']);
+        $this->View = $this->getMockBuilder('Cake\View\View')
+                ->setMethods(['append'])
+                ->getMock();
         $this->User = new UserHelper($this->View);
         $this->request = new Request();
     }
@@ -156,7 +158,9 @@ class UserHelperTest extends TestCase
      */
     public function testWelcome()
     {
-        $session = $this->getMock('Cake\Network\Session', ['read']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['read'])
+                ->getMock();
         $session->expects($this->at(0))
             ->method('read')
             ->with('Auth.User.id')
@@ -167,7 +171,9 @@ class UserHelperTest extends TestCase
             ->with('Auth.User.first_name')
             ->will($this->returnValue('david'));
 
-        $this->User->request = $this->getMock('Cake\Network\Request', ['session']);
+        $this->User->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session'])
+                ->getMock();
         $this->User->request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));
@@ -184,13 +190,17 @@ class UserHelperTest extends TestCase
      */
     public function testWelcomeNotLoggedInUser()
     {
-        $session = $this->getMock('Cake\Network\Session', ['read']);
+        $session = $this->getMockBuilder('Cake\Network\Session')
+                ->setMethods(['read'])
+                ->getMock();
         $session->expects($this->at(0))
             ->method('read')
             ->with('Auth.User.id')
             ->will($this->returnValue(null));
 
-        $this->User->request = $this->getMock('Cake\Network\Request', ['session']);
+        $this->User->request = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['session'])
+                ->getMock();
         $this->User->request->expects($this->any())
             ->method('session')
             ->will($this->returnValue($session));
@@ -222,7 +232,7 @@ class UserHelperTest extends TestCase
         $expected = '<p>reCaptcha is not configured! Please configure Users.reCaptcha.key</p>';
         $this->assertEquals($expected, $result);
     }
-    
+
     /**
      * Test add ReCaptcha field
      *


### PR DESCRIPTION
Refs #381 

Replaced the deprecated methods form PHPUnit.

The remaining warnings are caused by the use of 'Cake\TestSuite\TestCase::getMockForModel()', that uses the deprecated method 'getMock'.

The PR has already been done to the core and should be ready with Cakephp 3.2.11.
https://github.com/cakephp/cakephp/pull/8951
