### PR TITLE
Fix var names in SimpleCrudTrait actions templates when the UsersTable is extended

### DIFF
--- a/src/Template/Users/add.ctp
+++ b/src/Template/Users/add.ctp
@@ -17,7 +17,7 @@
     </ul>
 </div>
 <div class="users form large-10 medium-9 columns">
-    <?= $this->Form->create($Users); ?>
+    <?= $this->Form->create(${$tableAlias}); ?>
     <fieldset>
         <legend><?= __d('CakeDC/Users', 'Add User') ?></legend>
         <?php

--- a/src/Template/Users/edit.ctp
+++ b/src/Template/Users/edit.ctp
@@ -8,16 +8,21 @@
  * @copyright Copyright 2010 - 2015, Cake Development Corporation (http://cakedc.com)
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+
+$Users = ${$tableAlias};
 ?>
 <div class="actions columns large-2 medium-3">
     <h3><?= __d('CakeDC/Users', 'Actions') ?></h3>
     <ul class="side-nav">
-        <li><?= $this->Form->postLink(
+        <li>
+            <?php
+            echo $this->Form->postLink(
                 __d('CakeDC/Users', 'Delete'),
                 ['action' => 'delete', $Users->id],
                 ['confirm' => __d('CakeDC/Users', 'Are you sure you want to delete # {0}?', $Users->id)]
-            )
-        ?></li>
+            );
+            ?>
+        </li>
         <li><?= $this->Html->link(__d('CakeDC/Users', 'List Users'), ['action' => 'index']) ?></li>
         <li><?= $this->Html->link(__d('CakeDC/Users', 'List Accounts'), ['controller' => 'Accounts', 'action' => 'index']) ?> </li>
     </ul>

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -27,7 +27,7 @@
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($Users as $user): ?>
+    <?php foreach (${$tableAlias} as $user) : ?>
         <tr>
             <td><?= h($user->username) ?></td>
             <td><?= h($user->email) ?></td>

--- a/src/Template/Users/view.ctp
+++ b/src/Template/Users/view.ctp
@@ -8,6 +8,8 @@
  * @copyright Copyright 2010 - 2015, Cake Development Corporation (http://cakedc.com)
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+
+$Users = ${$tableAlias};
 ?>
 <div class="actions columns large-2 medium-3">
     <h3><?= __d('CakeDC/Users', 'Actions') ?></h3>
@@ -59,7 +61,7 @@
 <div class="related row">
     <div class="column large-12">
         <h4 class="subheader"><?= __d('CakeDC/Users', 'Related Accounts') ?></h4>
-        <?php if (!empty($Users->social_accounts)): ?>
+        <?php if (!empty($Users->social_accounts)) : ?>
             <table cellpadding="0" cellspacing="0">
                 <tr>
                     <th><?= __d('CakeDC/Users', 'Id') ?></th>
@@ -76,7 +78,7 @@
                     <th><?= __d('CakeDC/Users', 'Modified') ?></th>
                     <th class="actions"><?= __d('CakeDC/Users', 'Actions') ?></th>
                 </tr>
-                <?php foreach ($Users->social_accounts as $socialAccount): ?>
+                <?php foreach ($Users->social_accounts as $socialAccount) : ?>
                     <tr>
                         <td><?= h($socialAccount->id) ?></td>
                         <td><?= h($socialAccount->user_id) ?></td>


### PR DESCRIPTION
As you can see here:
https://github.com/CakeDC/users/blob/develop/src/Controller/Traits/SimpleCrudTrait.php#L29-54

SimpleCrudTrait set the variables to the view like:

        $this->set($tableAlias, $this->paginate($table));
        $this->set('tableAlias', $tableAlias);

This make it flexible when extending the UsersTable.

In the action templates however (add, edit, index and view), its is always used the variable **$Users**.

So if i extend the UsersTable to MyUsersTable, the variable that is set to the view is **$MyUsers** and i get the error that $Users id not defined.

This PR will fix that.