### PR TITLE
Update UserHelper.php

### DIFF
--- a/src/View/Helper/UserHelper.php
+++ b/src/View/Helper/UserHelper.php
@@ -102,9 +102,16 @@ class UserHelper extends Helper
      */
     public function link($title, $url = null, array $options = [])
     {
+        $_defaultOptions = [
+            'hash' => null
+        ];
+        $options = array_merge($_defaultOptions, $options);
         if ($this->isAuthorized($url)) {
+            if(isset($options['hash'])) {
+                $url = $options['hash'];
+            }
             $linkOptions = $options;
-            unset($linkOptions['before'], $linkOptions['after']);
+            unset($linkOptions['before'], $linkOptions['after'], $linkOptions['hash']);
             return Hash::get($options, 'before') . $this->Html->link($title, $url, $linkOptions) . Hash::get($options, 'after');
         }
 

--- a/src/View/Helper/UserHelper.php
+++ b/src/View/Helper/UserHelper.php
@@ -107,7 +107,7 @@ class UserHelper extends Helper
         ];
         $options = array_merge($_defaultOptions, $options);
         if ($this->isAuthorized($url)) {
-            if(isset($options['hash'])) {
+            if(!is_null($options['hash'])) {
                 $url = $options['hash'];
             }
             $linkOptions = $options;


### PR DESCRIPTION
Adds ability to authorize a hash link.  Useful for linking modal triggers.  You supply a hash to the options array with the hash you want and it will authorize the url then swap the link with the hash if authroized.

$this->Url->link('LinkText', [route], ['hash' => '#modal"])