### PR TITLE
Making social login public to get social links displayed in login page

### DIFF
--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -110,7 +110,8 @@ class UsersAuthComponent extends Component
             'requestResetPassword',
             'changePassword',
             'endpoint',
-            'authenticated'
+            'authenticated',
+            'socialLogin'
         ]);
     }
 


### PR DESCRIPTION
When using UserHelper::socialLogin, links were not being shown. 