### PR TITLE
[WIP] Improvements to SimpleRbac

### DIFF
--- a/Docs/Documentation/SimpleRbacAuthorize.md
+++ b/Docs/Documentation/SimpleRbacAuthorize.md
@@ -52,25 +52,42 @@ The ```default_role``` will be used to set the role of the registered users by d
 Permission rules syntax
 -----------------
 
-* Rules are evaluated top-down, first matching rule will apply
-* Each rule is defined:
-```php
-[
-    'role' => 'REQUIRED_NAME_OF_THE_ROLE_OR_[]_OR_*',
-    'prefix' => 'OPTIONAL_PREFIX_USED_OR_[]_OR_*_DEFAULT_NULL',
-    'extension' => 'OPTIONAL_PREFIX_USED_OR_[]_OR_*_DEFAULT_NULL',
-    'plugin' => 'OPTIONAL_NAME_OF_THE_PLUGIN_OR_[]_OR_*_DEFAULT_NULL',
-    'controller' => 'REQUIRED_NAME_OF_THE_CONTROLLER_OR_[]_OR_*'
-    'action' => 'REQUIRED_NAME_OF_ACTION_OR_[]_OR_*',
-    'allowed' => 'OPTIONAL_BOOLEAN_OR_CALLABLE_OR_INSTANCE_OF_RULE_DEFAULT_TRUE'
-]
-```
-* If no rule allowed = true is matched for a given user role and url, default return value will be false
-* Note for Superadmin access (permission to access ALL THE THINGS in your app) there is a specific Authorize Object provided
+* Permissions are evaluated top-down, first matching permission will apply
+* Each permission is an associative array of rules with following structure: `'value_to_check' => 'expected_value'`
+* `value_to_check` can be any key from user array or one of special keys:
+    * Routing params:
+        * `prefix`
+        * `plugin`
+        * `extension`
+        * `controller`
+        * `action`
+    * `role` - Alias/shortcut to field defined in `role_field` config value
+    * `allowed` - see below
+* If you have a user field that overlaps with special keys (eg. `$user->allowed`) you can prepend `user.` to key to force matching from user array (eg. `user.allowed`)
+* The keys can be placed in any order with exception of `allowed` which must be last one (see below)
+* `value_to_check` can be prepended with `*` to match everything except `expected_value`
+* `expected_value` can be one of following things:
+    * `*` will match absolutely everything
+    * A _string_/_integer_/_boolean_/etc - will match only the specified value
+    * An _array_ of strings/integers/booleans/etc (can be mixed). The rule will match if real value is equal to any of expected ones
+    * A callable/object (see below)
+* If any of rules fail, the permission is discarded and the next one is evaluated
+* A very special key `allowed` exists which has completely different behaviour:
+    * If `expected_value` is a callable/object then it's executed and the result is casted to boolean
+    * If `expected_value` is **not** a callable/object then it's simply casted to boolean
+    * The `*` is checked and if found the result is inverted
+    * The final boolean value is **the result of permission** checker. This means if it is `false` then no other permissions are checked and the user is denied access.
+    For this reason the `allowed` key must be placed at the end of permission since no other rules are executed after it
 
-Permission Callbacks
------------------
-You could use a callback in your 'allowed' to process complex authentication, like
+**Notes**:
+
+* For Superadmin access (permission to access ALL THE THINGS in your app) there is a specific Authorize Object provided
+* Permissions that do not have `controller` and/or `action` keys (or the inverted versions) are automatically discarded in order to prevent errors.
+If you need to match all controllers/actions you can explicitly do `'contoller' => '*'`
+* Key `user` (or the inverted version) is illegal (as it's impossible to match an array) and any permission containing it will be discarded
+* If the permission is discarded for the reasons stated above, a debug message will be logged
+
+**Permission Callbacks**: you could use a callback in your 'allowed' to process complex authentication, like
   - ownership
   - permissions stored in your database
   - permission based on an external service API call
@@ -78,10 +95,10 @@ You could use a callback in your 'allowed' to process complex authentication, li
 Example *ownership* callback, to allow users to edit their own Posts:
 
 ```php
-    'allowed' => function (array $user, $role, Request $request) {
-        $postId = Hash::get($request->params, 'pass.0');
-        $post = TableRegistry::get('Posts')->get($postId);
-        $userId = Hash::get($user, 'id');
+    'allowed' => function (array $user, $role, \Cake\Network\Request $request) {
+        $postId = \Cake\Utility\Hash::get($request->params, 'pass.0');
+        $post = \Cake\ORM\TableRegistry::get('Posts')->get($postId);
+        $userId = $user['id'];
         if (!empty($post->user_id) && !empty($userId)) {
             return $post->user_id === $userId;
         }
@@ -89,12 +106,36 @@ Example *ownership* callback, to allow users to edit their own Posts:
     }
 ```
 
-Permission Rules
-----------------
-You could use an instance of the \CakeDC\Users\Auth\Rules\Rule interface to reuse your custom rules
-Examples:
+**Permission Rules**: If you see that you are duplicating logic in your callables, you can create rule class to re-use the logic.
+For example, the above ownership callback is included in CakeDC\Users as `Owner` rule
 ```php
-'allowed' => new Owner() //will pick by default the post id from the first pass param
+'allowed' => new \CakeDC\Users\Auth\Rules\Owner() //will pick by default the post id from the first pass param
 ```
 Check the [Owner Rule](OwnerRule.md) documentation for more details
 
+Creating rule classes
+---------------------
+
+The only requirement is to implement `\CakeDC\Users\Auth\Rules\Rule` interface which has one method:
+
+```php
+class YourRule implements \CakeDC\Users\Auth\Rules\Rule
+{
+    /**
+     * Check the current entity is owned by the logged in user
+     *
+     * @param array $user Auth array with the logged in data
+     * @param string $role role of the user
+     * @param Request $request current request, used to get a default table if not provided
+     * @return bool
+     */
+    public function allowed(array $user, $role, Request $request)
+    {
+        // Your logic here
+    }
+}
+```
+
+This logic can be anything: database, external auth, etc.
+
+Also, if you are using DB, you can choose to extend `\CakeDC\Users\Auth\Rules\AbstractRule` since it provides convenience methods for reading from DB

--- a/src/Auth/Rules/AbstractRule.php
+++ b/src/Auth/Rules/AbstractRule.php
@@ -10,7 +10,10 @@
  */
 namespace CakeDC\Users\Auth\Rules;
 
+use Cake\Core\InstanceConfigTrait;
+use Cake\Datasource\ModelAwareTrait;
 use Cake\Network\Request;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -22,9 +25,9 @@ use OutOfBoundsException;
  */
 abstract class AbstractRule implements Rule
 {
-    use \Cake\Core\InstanceConfigTrait;
-    use \Cake\Datasource\ModelAwareTrait;
-    use \Cake\ORM\Locator\LocatorAwareTrait;
+    use InstanceConfigTrait;
+    use ModelAwareTrait;
+    use LocatorAwareTrait;
 
     /**
      * @var array default config

--- a/src/Auth/Rules/Rule.php
+++ b/src/Auth/Rules/Rule.php
@@ -21,7 +21,6 @@ interface Rule
      * @param string $role role of the user
      * @param Request $request current request, used to get a default table if not provided
      * @return bool
-     * @throws \OutOfBoundsException if table is not found or it doesn't have the expected fields
      */
     public function allowed(array $user, $role, Request $request);
 }

--- a/src/Auth/SimpleRbacAuthorize.php
+++ b/src/Auth/SimpleRbacAuthorize.php
@@ -287,8 +287,7 @@ class SimpleRbacAuthorize extends BaseAuthorize
             return true;
         }
 
-        if (
-            $possibleValues === '*' ||
+        if ($possibleValues === '*' ||
             in_array($value, $possibleArray) ||
             in_array(Inflector::camelize($value, '-'), $possibleArray)
         ) {

--- a/src/Auth/SimpleRbacAuthorize.php
+++ b/src/Auth/SimpleRbacAuthorize.php
@@ -217,9 +217,9 @@ class SimpleRbacAuthorize extends BaseAuthorize
         $permission += ['allowed' => true];
         $user_arr = ['user' => $user];
         $reserved = [
-            'prefix' => $request->params['prefix'],
+            'prefix' => isset($request->params['prefix']) ? $request->params['prefix'] : null,
             'plugin' => $request->plugin,
-            'extension' => $request->params['_ext'],
+            'extension' => isset($request->params['_ext']) ? $request->params['_ext'] : null,
             'controller' => $request->controller,
             'action' => $request->action,
         ];

--- a/src/Auth/SimpleRbacAuthorize.php
+++ b/src/Auth/SimpleRbacAuthorize.php
@@ -205,9 +205,21 @@ class SimpleRbacAuthorize extends BaseAuthorize
      */
     protected function _matchRule(array $permission, array $user, $role, Request $request)
     {
-        if (!isset($permission['controller'], $permission['action'])) {
+        $issetController = isset($permission['controller']) || isset($permission['*controller']);
+        $issetAction = isset($permission['action']) || isset($permission['*action']);
+        $issetUser = isset($permission['user']) || isset($permission['*user']);
+
+        if (!$issetController || !$issetAction) {
             $this->log(
                 __d('CakeDC/Users', "Cannot evaluate permission when 'controller' and/or 'action' keys are absent"),
+                LogLevel::DEBUG
+            );
+
+            return false;
+        }
+        if ($issetUser) {
+            $this->log(
+                __d('CakeDC/Users', "Permission key 'user' is illegal, cannot evaluate the permission"),
                 LogLevel::DEBUG
             );
 
@@ -240,7 +252,7 @@ class SimpleRbacAuthorize extends BaseAuthorize
             } elseif (array_key_exists($key, $reserved)) {
                 $return = $this->_matchOrAsterisk($value, $reserved[$key], true);
             } else {
-                if (!$this->_startsWith($key, 'user')) {
+                if (!$this->_startsWith($key, 'user.')) {
                     $key = 'user.' . $key;
                 }
 

--- a/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
+++ b/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
@@ -795,7 +795,7 @@ class SimpleRbacAuthorizeTest extends TestCase
                     'controller' => '*',
                     'action' => 'one',
                     'allowed' => false,
-                ],],
+                ]],
                 //user
                 [
                     'id' => 1,
@@ -969,7 +969,6 @@ class SimpleRbacAuthorizeTest extends TestCase
      */
     public function testBadPermission($permissions, $user, $requestParams, $expectedMsg)
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|SimpleRbacAuthorize $simpleRbacAuthorize */
         $simpleRbacAuthorize = $this->getMockBuilder(SimpleRbacAuthorize::class)
             ->setMethods(['_loadPermissions', 'log'])
             ->disableOriginalConstructor()
@@ -1117,7 +1116,7 @@ class SimpleRbacAuthorizeTest extends TestCase
      * @param array $params
      * @return \Cake\Network\Request
      */
-    protected function _requestFromArray ($params)
+    protected function _requestFromArray($params)
     {
         $request = new Request();
         $request->plugin = Hash::get($params, 'plugin');

--- a/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
+++ b/tests/TestCase/Auth/SimpleRbacAuthorizeTest.php
@@ -14,12 +14,11 @@ namespace CakeDC\Users\Test\TestCase\Auth;
 use CakeDC\Users\Auth\Rules\Rule;
 use CakeDC\Users\Auth\SimpleRbacAuthorize;
 use Cake\Controller\ComponentRegistry;
-use Cake\Controller\Controller;
-use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use Psr\Log\LogLevel;
 use ReflectionClass;
 
 class SimpleRbacAuthorizeTest extends TestCase
@@ -171,19 +170,7 @@ class SimpleRbacAuthorizeTest extends TestCase
     public function testAuthorize($permissions, $user, $requestParams, $expected, $msg = null)
     {
         $this->simpleRbacAuthorize = $this->preparePermissions($permissions);
-        $request = new Request();
-        $request->plugin = Hash::get($requestParams, 'plugin');
-        $request->controller = $requestParams['controller'];
-        $request->action = $requestParams['action'];
-        $prefix = Hash::get($requestParams, 'prefix');
-        $request->params = [];
-        if ($prefix) {
-            $request->params['prefix'] = $prefix;
-        }
-        $extension = Hash::get($requestParams, '_ext');
-        if ($extension) {
-            $request->params['_ext'] = $extension;
-        }
+        $request = $this->_requestFromArray($requestParams);
 
         $result = $this->simpleRbacAuthorize->authorize($user, $request);
         $this->assertSame($expected, $result, $msg);
@@ -199,6 +186,139 @@ class SimpleRbacAuthorizeTest extends TestCase
             ->willReturn(true);
 
         return [
+            'star-invert' => [
+                //permissions
+                [[
+                    '*plugin' => 'Tests',
+                    '*role' => 'test',
+                    '*controller' => 'Tests',
+                    '*action' => 'test',
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'something',
+                ],
+                //request
+                [
+                    'plugin' => 'something',
+                    'controller' => 'something',
+                    'action' => 'something'
+                ],
+                //expected
+                true
+            ],
+            'star-invert-deny' => [
+                //permissions
+                [[
+                    '*plugin' => 'Tests',
+                    '*role' => 'test',
+                    '*controller' => 'Tests',
+                    '*action' => 'test',
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'something',
+                ],
+                //request
+                [
+                    'plugin' => 'something',
+                    'controller' => 'something',
+                    'action' => 'test'
+                ],
+                //expected
+                false
+            ],
+            'user-arr' => [
+                //permissions
+                [
+                    [
+                        'username' => 'luke',
+                        'user.id' => 1,
+                        'profile.id' => 256,
+                        'user.profile.signature' => "Hi I'm luke",
+                        'user.allowed' => false,
+                        'controller' => 'Tests',
+                        'action' => 'one'
+                    ],
+                ],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                    'profile' => [
+                        'id' => 256,
+                        'signature' => "Hi I'm luke"
+                    ],
+                    'allowed' => false
+                ],
+                //request
+                [
+                    'controller' => 'Tests',
+                    'action' => 'one'
+                ],
+                //expected
+                true
+            ],
+            'evaluate-order' => [
+                //permissions
+                [
+                    [
+                        'allowed' => false,
+                        function () {
+                            throw new \Exception();
+                        },
+                        'controller' => 'Tests',
+                        'action' => 'one'
+                    ],
+                ],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'controller' => 'Tests',
+                    'action' => 'one'
+                ],
+                //expected
+                false
+            ],
+            'multiple-callables' => [
+                //permissions
+                [
+                    [
+                        function () {
+                            return true;
+                        },
+                        clone $trueRuleMock,
+                        function () {
+                            return true;
+                        },
+                        'controller' => 'Tests',
+                        'action' => 'one'
+                    ],
+                ],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'controller' => 'Tests',
+                    'action' => 'one'
+                ],
+                //expected
+                true
+            ],
             'happy-strict-all' => [
                 //permissions
                 [[
@@ -501,7 +621,7 @@ class SimpleRbacAuthorizeTest extends TestCase
                 //expected
                 true
             ],
-            'happy-array' => [
+            'happy-array-deny' => [
                 //permissions
                 [[
                     'plugin' => ['Tests'],
@@ -667,23 +787,15 @@ class SimpleRbacAuthorizeTest extends TestCase
                 //expected
                 true
             ],
-            'array-prefix' => [
+            'array-prefix-deny' => [
                 //permissions
-                [
-                    [
-                        'role' => ['test'],
-                        'prefix' => ['one', 'admin'],
-                        'controller' => '*',
-                        'action' => 'one',
-                        'allowed' => false,
-                    ],
-                    [
-                        'role' => ['test'],
-                        'prefix' => ['one', 'admin'],
-                        'controller' => '*',
-                        'action' => '*',
-                    ],
-                ],
+                [[
+                    'role' => ['test'],
+                    'prefix' => ['one', 'admin'],
+                    'controller' => '*',
+                    'action' => 'one',
+                    'allowed' => false,
+                ],],
                 //user
                 [
                     'id' => 1,
@@ -796,23 +908,15 @@ class SimpleRbacAuthorizeTest extends TestCase
                 //expected
                 true
             ],
-            'array-ext' => [
+            'array-ext-deny' => [
                 //permissions
-                [
-                    [
-                        'role' => ['test'],
-                        'extension' => ['csv', 'docx'],
-                        'controller' => '*',
-                        'action' => 'one',
-                        'allowed' => false,
-                    ],
-                    [
-                        'role' => ['test'],
-                        'extension' => ['csv', 'docx'],
-                        'controller' => '*',
-                        'action' => '*',
-                    ],
-                ],
+                [[
+                    'role' => ['test'],
+                    'extension' => ['csv', 'docx'],
+                    'controller' => '*',
+                    'action' => 'one',
+                    'allowed' => false,
+                ]],
                 //user
                 [
                     'id' => 1,
@@ -853,5 +957,182 @@ class SimpleRbacAuthorizeTest extends TestCase
                 true
             ],
         ];
+    }
+
+    /**
+     * @dataProvider badPermissionProvider
+     *
+     * @param array $permissions
+     * @param array $user
+     * @param array $requestParams
+     * @param string $expectedMsg
+     */
+    public function testBadPermission($permissions, $user, $requestParams, $expectedMsg)
+    {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|SimpleRbacAuthorize $simpleRbacAuthorize */
+        $simpleRbacAuthorize = $this->getMockBuilder(SimpleRbacAuthorize::class)
+            ->setMethods(['_loadPermissions', 'log'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $simpleRbacAuthorize
+            ->expects($this->once())
+            ->method('log')
+            ->with($expectedMsg, LogLevel::DEBUG);
+
+        $simpleRbacAuthorize->config('permissions', $permissions);
+        $request = $this->_requestFromArray($requestParams);
+
+        $simpleRbacAuthorize->authorize($user, $request);
+    }
+
+    public function badPermissionProvider()
+    {
+        return [
+            'no-controller' => [
+                //permissions
+                [[
+                    'plugin' => 'Tests',
+                    'role' => 'test',
+                    //'controller' => 'Tests',
+                    'action' => 'test',
+                    'allowed' => true,
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'plugin' => 'Tests',
+                    'controller' => 'Tests',
+                    'action' => 'test'
+                ],
+                //expected
+                __d('CakeDC/Users', "Cannot evaluate permission when 'controller' and/or 'action' keys are absent"),
+            ],
+            'no-action' => [
+                //permissions
+                [[
+                    'plugin' => 'Tests',
+                    'role' => 'test',
+                    'controller' => 'Tests',
+                    //'action' => 'test',
+                    'allowed' => true,
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'plugin' => 'Tests',
+                    'controller' => 'Tests',
+                    'action' => 'test'
+                ],
+                //expected
+                __d('CakeDC/Users', "Cannot evaluate permission when 'controller' and/or 'action' keys are absent"),
+            ],
+            'no-controller-and-action' => [
+                //permissions
+                [[
+                    'plugin' => 'Tests',
+                    'role' => 'test',
+                    //'controller' => 'Tests',
+                    //'action' => 'test',
+                    'allowed' => true,
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'plugin' => 'Tests',
+                    'controller' => 'Tests',
+                    'action' => 'test'
+                ],
+                //expected
+                __d('CakeDC/Users', "Cannot evaluate permission when 'controller' and/or 'action' keys are absent"),
+            ],
+            'no-controller and user-key' => [
+                //permissions
+                [[
+                    'plugin' => 'Tests',
+                    'role' => 'test',
+                    //'controller' => 'Tests',
+                    'action' => 'test',
+                    'allowed' => true,
+                    'user' => 'something',
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'plugin' => 'Tests',
+                    'controller' => 'Tests',
+                    'action' => 'test'
+                ],
+                //expected
+                __d('CakeDC/Users', "Cannot evaluate permission when 'controller' and/or 'action' keys are absent"),
+            ],
+            'user-key' => [
+                //permissions
+                [[
+                    'plugin' => 'Tests',
+                    'role' => 'test',
+                    'controller' => 'Tests',
+                    'action' => 'test',
+                    'allowed' => true,
+                    'user' => 'something',
+                ]],
+                //user
+                [
+                    'id' => 1,
+                    'username' => 'luke',
+                    'role' => 'test',
+                ],
+                //request
+                [
+                    'plugin' => 'Tests',
+                    'controller' => 'Tests',
+                    'action' => 'test'
+                ],
+                //expected
+                __d('CakeDC/Users', "Permission key 'user' is illegal, cannot evaluate the permission"),
+            ],
+        ];
+    }
+
+    /**
+     * @param array $params
+     * @return \Cake\Network\Request
+     */
+    protected function _requestFromArray ($params)
+    {
+        $request = new Request();
+        $request->plugin = Hash::get($params, 'plugin');
+        $request->controller = $params['controller'];
+        $request->action = $params['action'];
+        $prefix = Hash::get($params, 'prefix');
+        $request->params = [];
+        if ($prefix) {
+            $request->params['prefix'] = $prefix;
+        }
+        $extension = Hash::get($params, '_ext');
+        if ($extension) {
+            $request->params['_ext'] = $extension;
+        }
+
+        return $request;
     }
 }


### PR DESCRIPTION
This is my take on #407 plus some additional things. It is completely BC (according to existing tests) and features several improvements:

- Permission is evaluated top-down (using `foreach`) so if a rule fails, it won't compare the next one and comparison is done in user-defined order (vs previously hard-coded `role -> prefix -> plugin -> extension -> controller -> action -> allowed`)
- Callables/instances of `\CakeDC\Users\Auth\Rules\Rule` **do not** have to be placed under `allowed` key and you can use many of those inside one permission
- You can access any value from user array using dot notation (eg. `'role.title' => 'Admin'` or `'role.id' => 2`)
- You can access values from user array that are reserved (eg. `allowed`) by prepending `user.` to the array key (eg. `user.allowed`)
- Anything under `allowed` key will be cast to boolean 
- If the array key begins with `*` the result will be inverted (eg. `'*controller' => 'Test'` will match any controller **besides** `Test`)
- If the permission array is missing `controller` and/or `action` key(s), it will be discarded and *a message will be logged* (previously it would fail silently)

I think that's about it... If people think this is a good change I'll go ahead and write the additional tests.

One things that bugs be however is that the `$role` variable that is passed to `_matchRule` is not used anywhere besides being passed to callable/`\CakeDC\Users\Auth\Rules\Rule` since we are reading directly from user array now