### PR TITLE
Fixed non-BC change in a patch release (3.2.0 -> 3.2.1) 

### DIFF
--- a/src/View/Helper/AuthLinkHelper.php
+++ b/src/View/Helper/AuthLinkHelper.php
@@ -16,8 +16,8 @@ class AuthLinkHelper extends HtmlHelper
     /**
      * Generate a link if the target url is authorized for the logged in user
      *
-     * @param type $title link's title.
-     * @param type $url url that the user is making request.
+     * @param string $title link's title.
+     * @param string|array|null $url url that the user is making request.
      * @param array $options Array with option data.
      * @return string
      */
@@ -34,9 +34,9 @@ class AuthLinkHelper extends HtmlHelper
     }
 
     /**
-     * Retunrs true if the target url is authorized for the logged in user
+     * Returns true if the target url is authorized for the logged in user
      *
-     * @param type $url url that the user is making request.
+     * @param string|array|null $url url that the user is making request.
      * @return bool
      */
     public function isAuthorized($url = null)

--- a/src/View/Helper/UserHelper.php
+++ b/src/View/Helper/UserHelper.php
@@ -138,4 +138,42 @@ class UserHelper extends Helper
             'data-sitekey' => Configure::read('Users.reCaptcha.key')
         ]);
     }
+
+    /**
+     * Generate a link if the target url is authorized for the logged in user
+     *
+     * @deprecated Since 3.2.1. Use AuthLinkHelper::link() instead
+     *
+     * @param string $title link's title.
+     * @param string|array|null $url url that the user is making request.
+     * @param array $options Array with option data.
+     * @return string
+     */
+    public function link($title, $url = null, array $options = [])
+    {
+        trigger_error(
+            'UserHelper::link() deprecated since 3.2.1. Use AuthLinkHelper::link() instead',
+            E_USER_DEPRECATED
+        );
+
+        return $this->AuthLink->link($title, $url, $options);
+    }
+
+    /**
+     * Returns true if the target url is authorized for the logged in user
+     *
+     * @deprecated Since 3.2.1. Use AuthLinkHelper::link() instead
+     *
+     * @param string|array|null $url url that the user is making request.
+     * @return bool
+     */
+    public function isAuthorized($url = null)
+    {
+        trigger_error(
+            'UserHelper::isAuthorized() deprecated since 3.2.1. Use AuthLinkHelper::isAuthorized() instead',
+            E_USER_DEPRECATED
+        );
+
+        return $this->AuthLink->isAuthorized($url);
+    }
 }


### PR DESCRIPTION
So, yeah...
![userhelper-link broken](https://cloud.githubusercontent.com/assets/2865341/17516058/de0e61cc-5e44-11e6-9ecb-ed4c0a26d2b0.png)
Quite a bit of stuff is broken... I guess this was just an oversight?

Also fixed some docblocks