### PR TITLE
Removed beta status from doc now that plugin is stable

### DIFF
--- a/Docs/Home.md
+++ b/Docs/Home.md
@@ -1,9 +1,6 @@
 Home
 ====
 
-IMPORANT: Current status is **BETA**. We are still working on improving the unit test coverage and docs
-Plugin is usable now if you want to download and take a look. PRs and Issues welcome!
-
 The **Users** Plugin allow users to register and login, manage their profile, etc. It also allows admins to manage the users.
 
 The plugin is thought as a base to extend your app specific users controller and model from.


### PR DESCRIPTION
According to commit 3dad61c365198ed0ca89c9a5ac921eb7e9da78be this plugin is no longer in beta (unless I've misunderstood what the current readme is implying - the table is a little confusing). So have removed the beta status from the docs.