### PR TITLE
add allowed to manage the AuthLinkHelper when action is allowed

### DIFF
--- a/src/View/Helper/AuthLinkHelper.php
+++ b/src/View/Helper/AuthLinkHelper.php
@@ -18,15 +18,21 @@ class AuthLinkHelper extends HtmlHelper
      *
      * @param string $title link's title.
      * @param string|array|null $url url that the user is making request.
-     * @param array $options Array with option data.
-     * @return string
+     * @param array $options Array with option data. Extra options include
+     * 'before' and 'after' to quickly inject some html code in the link, like icons etc
+     * 'allowed' to manage if the link should be displayed, default is null to check isAuthorized
+     * @return string|bool
      */
     public function link($title, $url = null, array $options = [])
     {
-        if ($this->isAuthorized($url)) {
-            $linkOptions = $options;
-            unset($linkOptions['before'], $linkOptions['after']);
+        $linkOptions = $options;
+        unset($linkOptions['before'], $linkOptions['after'], $linkOptions['allowed']);
+        $allowed = Hash::get($options, 'allowed');
 
+        if ($allowed === false) {
+            return false;
+        }
+        if ($allowed === true || $this->isAuthorized($url)) {
             return Hash::get($options, 'before') . parent::link($title, $url, $linkOptions) . Hash::get($options, 'after');
         }
 

--- a/tests/TestCase/View/Helper/AuthLinkHelperTest.php
+++ b/tests/TestCase/View/Helper/AuthLinkHelperTest.php
@@ -78,6 +78,47 @@ class AuthLinkHelperTest extends TestCase
         $this->assertSame('before_<a href="/" class="link-class">title</a>_after', $link);
     }
 
+    /**
+     * Test link
+     *
+     * @return void
+     */
+    public function testLinkAuthorizedAllowedTrue()
+    {
+        $view = new View();
+        $eventManagerMock = $this->getMockBuilder('Cake\Event\EventManager')
+            ->setMethods(['dispatch'])
+            ->getMock();
+        $view->eventManager($eventManagerMock);
+        $this->AuthLink = new AuthLinkHelper($view);
+        $result = new Event('dispatch-result');
+        $result->result = true;
+        $eventManagerMock->expects($this->never())
+            ->method('dispatch');
+
+        $link = $this->AuthLink->link('title', '/', ['allowed' => true, 'before' => 'before_', 'after' => '_after', 'class' => 'link-class']);
+        $this->assertSame('before_<a href="/" class="link-class">title</a>_after', $link);
+    }
+
+    /**
+     * Test link
+     *
+     * @return void
+     */
+    public function testLinkAuthorizedAllowedFalse()
+    {
+        $view = new View();
+        $eventManagerMock = $this->getMockBuilder('Cake\Event\EventManager')
+            ->setMethods(['dispatch'])
+            ->getMock();
+        $view->eventManager($eventManagerMock);
+        $this->AuthLink = new AuthLinkHelper($view);
+        $result = new Event('dispatch-result');
+        $eventManagerMock->expects($this->never())
+            ->method('dispatch');
+        $link = $this->AuthLink->link('title', '/', ['allowed' => false, 'before' => 'before_', 'after' => '_after', 'class' => 'link-class']);
+        $this->assertFalse($link);
+    }
 
     /**
      * Test isAuthorized


### PR DESCRIPTION
AuthLinkHelper is not able to detect the Auth->allowed actions in other controllers, setting the link as allowed will ignore the isAuthorized check if allowed is true or false, and check for authorized if is null (default value)