### PR TITLE
Fix require-dev move to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,16 +27,16 @@
         "source": "https://github.com/CakeDC/users"
     },
     "require": {
-        "cakephp/cakephp": ">=3.2.9 <4.0.0"
+        "cakephp/cakephp": ">=3.2.9 <4.0.0",
+        "league/oauth2-google": "@stable",
+        "league/oauth2-facebook": "@stable",
+        "league/oauth2-instagram": "@stable",
+        "league/oauth2-linkedin": "@stable",
+        "google/recaptcha": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",
-        "cakephp/cakephp-codesniffer": "^2.0",
-        "league/oauth2-facebook": "@stable",
-        "league/oauth2-instagram": "@stable",
-        "league/oauth2-google": "@stable",
-        "league/oauth2-linkedin": "@stable",
-        "google/recaptcha": "@stable"
+        "cakephp/cakephp-codesniffer": "^2.0"
     },
     "suggest": {
         "league/oauth1-client": "Provides Social Authentication with Twitter",


### PR DESCRIPTION
OK is 
"require": {
        "cakephp/cakephp": ">=3.2.9 <4.0.0",
        "league/oauth2-google": "@stable",
        "league/oauth2-facebook": "@stable",
        "league/oauth2-instagram": "@stable",
        "league/oauth2-linkedin": "@stable",
        "google/recaptcha": "~1.1"
    },
    "require-dev": {
        "phpunit/phpunit": "@stable",
        "cakephp/cakephp-codesniffer": "^2.0"
    },