### PR TITLE
Looking up for checkbox value on rememberme

### DIFF
--- a/src/Controller/Component/RememberMeComponent.php
+++ b/src/Controller/Component/RememberMeComponent.php
@@ -106,7 +106,13 @@ class RememberMeComponent extends Component
         if (empty($user)) {
             return;
         }
+
         $user['user_agent'] = $this->request->header('User-Agent');
+
+        if (!(bool)$event->subject()->request->data(Configure::read('Users.Key.Data.rememberMe'))) {
+            return;
+        }
+
         $this->Cookie->write($this->_cookieName, $user);
     }
 


### PR DESCRIPTION
RememberMe Component was assumed to be enabled all the time, no matter what is the checkbox value on the login page, so we create `remember_me` cookie only if the checkbox is enabled.