### PR TITLE
Fixing GoogleAuthenticator component for v1.6 of twofactorauth 

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -69,9 +69,7 @@ $config = [
             // QR-code provider (more on this later)
             'qrcodeprovider' => null,
             // Random Number Generator provider (more on this later)
-            'rngprovider' => null,
-            // Key used for encrypting the user credentials, leave this false to use Security.salt
-            'encryptionKey' => false
+            'rngprovider' => null
         ],
         'Profile' => [
             //Allow view other users profiles

--- a/src/Controller/Component/GoogleAuthenticatorComponent.php
+++ b/src/Controller/Component/GoogleAuthenticatorComponent.php
@@ -34,8 +34,7 @@ class GoogleAuthenticatorComponent extends Component
                 Configure::read('Users.GoogleAuthenticator.period'),
                 Configure::read('Users.GoogleAuthenticator.algorithm'),
                 Configure::read('Users.GoogleAuthenticator.qrcodeprovider'),
-                Configure::read('Users.GoogleAuthenticator.rngprovider'),
-                Configure::read('Users.GoogleAuthenticator.encryptionKey')
+                Configure::read('Users.GoogleAuthenticator.rngprovider')
             );
         }
     }


### PR DESCRIPTION
* 1.6 upgrade of Google Authenticator changed the number of params in constructor.
* Reference Issue: #500 