### PR TITLE
Fix Requirements version numbers not matching with README

### DIFF
--- a/Docs/Home.md
+++ b/Docs/Home.md
@@ -10,8 +10,8 @@ That it works out of the box doesn't mean it is thought to be used exactly like 
 Requirements
 ------------
 
-* CakePHP 3.1.*
-* PHP 5.4.16+
+* CakePHP 3.2.9+
+* PHP 5.5.9+
 
 Documentation
 -------------


### PR DESCRIPTION
The version numbers of the Requirements on the Docs/Home page are older than those on the README. I updated the Home page version numbers.