### PR TITLE
Patch of bug #544 Changed all setError calls back to error calls

### DIFF
--- a/src/Shell/UsersShell.php
+++ b/src/Shell/UsersShell.php
@@ -112,7 +112,7 @@ class UsersShell extends Shell
     {
         $password = Hash::get($this->args, 0);
         if (empty($password)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a password.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a password.'));
         }
         $hashedPassword = $this->_generatedHashedPassword($password);
         $this->Users->updateAll(['password' => $hashedPassword], ['id IS NOT NULL']);
@@ -135,10 +135,10 @@ class UsersShell extends Shell
         $username = Hash::get($this->args, 0);
         $password = Hash::get($this->args, 1);
         if (empty($username)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a username.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a username.'));
         }
         if (empty($password)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a password.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a password.'));
         }
         $data = [
             'password' => $password
@@ -163,10 +163,10 @@ class UsersShell extends Shell
         $username = Hash::get($this->args, 0);
         $role = Hash::get($this->args, 1);
         if (empty($username)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a username.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a username.'));
         }
         if (empty($role)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a role.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a role.'));
         }
         $data = [
             'role' => $role
@@ -215,7 +215,7 @@ class UsersShell extends Shell
     {
         $reference = Hash::get($this->args, 0);
         if (empty($reference)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a username or email.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a username or email.'));
         }
         $resetUser = $this->Users->resetToken($reference, [
             'expiration' => Configure::read('Users.Token.expiration'),
@@ -227,7 +227,7 @@ class UsersShell extends Shell
             $this->out($msg);
         } else {
             $msg = __d('CakeDC/Users', 'The password token could not be generated. Please try again');
-            $this->setError($msg);
+            $this->error($msg);
         }
     }
 
@@ -241,7 +241,7 @@ class UsersShell extends Shell
     {
         $username = Hash::get($this->args, 0);
         if (empty($username)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a username.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a username.'));
         }
         $data = [
             'active' => $active
@@ -316,7 +316,7 @@ class UsersShell extends Shell
     {
         $user = $this->Users->find()->where(['username' => $username])->first();
         if (empty($user)) {
-            $this->setError(__d('CakeDC/Users', 'The user was not found.'));
+            $this->error(__d('CakeDC/Users', 'The user was not found.'));
         }
         $user = $this->Users->patchEntity($user, $data);
         collection($data)->filter(function ($value, $field) use ($user) {
@@ -338,7 +338,7 @@ class UsersShell extends Shell
     {
         $username = Hash::get($this->args, 0);
         if (empty($username)) {
-            $this->setError(__d('CakeDC/Users', 'Please enter a username.'));
+            $this->error(__d('CakeDC/Users', 'Please enter a username.'));
         }
         $user = $this->Users->find()->where(['username' => $username])->first();
         if (isset($this->Users->SocialAccounts)) {
@@ -346,7 +346,7 @@ class UsersShell extends Shell
         }
         $deleteUser = $this->Users->delete($user);
         if (!$deleteUser) {
-            $this->setError(__d('CakeDC/Users', 'The user {0} was not deleted. Please try again', $username));
+            $this->error(__d('CakeDC/Users', 'The user {0} was not deleted. Please try again', $username));
         }
         $this->out(__d('CakeDC/Users', 'The user {0} was deleted successfully', $username));
     }


### PR DESCRIPTION
Patch to get UserShell back in working state.

This fails on one test.
UsersShellTest::testResetAllPasswordsNoPassingParams

This test expects a call to the setError method
I guess there was a plan to implement the setError method.