### PR TITLE
Allow upgrade to CakePHP 3.5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "source": "https://github.com/CakeDC/users"
     },
     "require": {
-        "cakephp/cakephp": "~3.4.0",
+        "cakephp/cakephp": "^3.4.0",
         "cakedc/auth": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Change Tilde Version Range to Caret Version Range to allow upgrading to CakePHP 3.5.x