### PR TITLE
Resend Validation Email

### DIFF
--- a/src/Model/Behavior/RegisterBehavior.php
+++ b/src/Model/Behavior/RegisterBehavior.php
@@ -197,4 +197,22 @@ class RegisterBehavior extends BaseTokenBehavior
 
         return $validator;
     }
+
+    /**
+     * @param EntityInterface $user User information
+     * @param array $options ['tokenExpiration]
+     * @return bool|EntityInterface
+     */
+    public function resendValidationEmail($user, $options)
+    {
+        $tokenExpiration = Hash::get($options, 'token_expiration');
+        $emailClass = Hash::get($options, 'email_class');
+        $user = $this->_updateActive($user, true, $tokenExpiration);
+        $userSaved = $this->_table->saveOrFail($user);
+        if ($userSaved) {
+            $this->Email->sendValidationEmail($userSaved, $emailClass);
+        }
+
+        return $userSaved;
+    }
 }

--- a/src/Model/Behavior/RegisterBehavior.php
+++ b/src/Model/Behavior/RegisterBehavior.php
@@ -205,6 +205,10 @@ class RegisterBehavior extends BaseTokenBehavior
      */
     public function resendValidationEmail($user, $options)
     {
+        if ($user->active) {
+            throw new UserAlreadyActiveException(__d('CakeDC/Users', "User account already validated"));
+        }
+
         $tokenExpiration = Hash::get($options, 'token_expiration');
         $emailClass = Hash::get($options, 'email_class');
         $user = $this->_updateActive($user, true, $tokenExpiration);

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -315,4 +315,29 @@ class RegisterBehaviorTest extends TestCase
         ]);
         $this->assertSame('emperor', $result['role']);
     }
+
+    /**
+     * Test resendValidationEmail method
+     *
+     * @return void
+     */
+    public function testResendValidationEmail()
+    { 
+        $user = [
+            'username' => 'testuser',
+            'email' => 'testuser@test.com',
+            'password' => 'password',
+            'password_confirm' => 'password',
+            'first_name' => 'test',
+            'last_name' => 'user',
+            'tos' => 1
+        ];
+        $result = $this->Table->register($this->Table->newEntity(), $user, ['token_expiration' => 3600, 'validate_email' => 1, 'email_class' => $this->Email]);
+        $this->assertFalse($result->active);
+        $originalExpiration = $result->token_expires;
+        $updatedResult = $this->Table->resendValidationEmail($result, ['token_expiration' => 3600, 'email_class' => $this->Email]);
+        $this->assertNotEmpty($updatedResult);
+        $this->assertFalse($updatedResult->active);
+        $this->assertNotEquals($updatedResult->token_expires, $originalExpiration);
+    }
 }

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -360,9 +360,7 @@ class RegisterBehaviorTest extends TestCase
             'tos' => 1
         ];
         $result = $this->Table->register($this->Table->newEntity(), $user, ['token_expiration' => 3600, 'validate_email' => 1, 'email_class' => $this->Email]);
-        $this->assertFalse($result->active);
         $activeUser = $this->Table->activateUser($result);
-        $this->assertTrue($activeUser->active);
         $this->expectException(UserAlreadyActiveException::class);
         $updatedResult = $this->Table->resendValidationEmail($activeUser, ['token_expiration' => 4000, 'email_class' => $this->Email]);
     }

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -322,7 +322,7 @@ class RegisterBehaviorTest extends TestCase
      * @return void
      */
     public function testResendValidationEmail()
-    { 
+    {
         $user = [
             'username' => 'testuser',
             'email' => 'testuser@test.com',

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -362,8 +362,8 @@ class RegisterBehaviorTest extends TestCase
         $result = $this->Table->register($this->Table->newEntity(), $user, ['token_expiration' => 3600, 'validate_email' => 1, 'email_class' => $this->Email]);
         $this->assertFalse($result->active);
         $activeUser = $this->Table->activateUser($result);
-        $this->assertTrue($result->active);
+        $this->assertTrue($activeUser->active);
         $this->expectException(UserAlreadyActiveException::class);
-        $updatedResult = $this->Table->resendValidationEmail($result, ['token_expiration' => 4000, 'email_class' => $this->Email]);
+        $updatedResult = $this->Table->resendValidationEmail($activeUser, ['token_expiration' => 4000, 'email_class' => $this->Email]);
     }
 }

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -12,11 +12,11 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
+use CakeDC\Users\Exception\UserAlreadyActiveException;
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use CakeDC\Users\Exception\UserAlreadyActiveException;
 use InvalidArgumentException;
 
 /**

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -335,9 +335,10 @@ class RegisterBehaviorTest extends TestCase
         $result = $this->Table->register($this->Table->newEntity(), $user, ['token_expiration' => 3600, 'validate_email' => 1, 'email_class' => $this->Email]);
         $this->assertFalse($result->active);
         $originalExpiration = $result->token_expires;
-        $updatedResult = $this->Table->resendValidationEmail($result, ['token_expiration' => 3600, 'email_class' => $this->Email]);
+        $updatedResult = $this->Table->resendValidationEmail($result, ['token_expiration' => 4000, 'email_class' => $this->Email]);
         $this->assertNotEmpty($updatedResult);
         $this->assertFalse($updatedResult->active);
-        $this->assertNotEquals($updatedResult->token_expires, $originalExpiration);
+        $newExpiration = $updatedResult->token_expires;
+        $this->assertNotEquals($originalExpiration, $newExpiration);
     }
 }


### PR DESCRIPTION
#454 

Based on the register method, allow for a new registration token to be created as well as resetting the token registration time based on the option for `token_expiration` in seconds.
Add a test to check that when this method is called, the token expiration is changed.

EDIT: 

The test was originally failing in PHP <= PHP 7.0 due to the `token_expiration` being the same in seconds for the registration and the update. The test takes less than a second so the values were reading as the same time.