### PR TITLE
Prevent conflict between CsrfComponent and CsrfProtectionMiddleware

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -28,7 +28,9 @@ class AppController extends BaseController
     {
         parent::initialize();
         $this->loadComponent('Security');
-        $this->loadComponent('Csrf');
+        if ($this->request->getParam('_csrfToken') === false) {
+            $this->loadComponent('Csrf');
+        }
         $this->loadComponent('CakeDC/Users.UsersAuth');
     }
 }


### PR DESCRIPTION
I am currently playing with next version of Cake (3.5.x). 🎉 

Since `CsrfComponent` is deprecated starting from 3.5, I have switched my app to `Cake\Http\Middleware\CsrfProtectionMiddleware`.

CakeDC/Users makes use of `CsrfComponent`, so, when `CsrfProtectionMiddleware` is enabled application wide, `CsrfComponent` enabled in CakeDC/Users overrides `CsrfProtectionMiddleware` injected `_csrfToken` causing `CsrfProtectionMiddleware` to throw a `InvalidCsrfTokenException `.

Currently, i am using this code in my `AppController` to disable `CsrfComponent` for CakeDC/Users plugin

```php
if ($event->getSubject()->request->getParam('plugin') === 'CakeDC/Users') {
    $this->getEventManager()->off($this->Csrf);
}
```

However, it would be better to check if `_csrfToken` is already defined in request param before loading `CsrfComponent` to prevent overriding `CsrfProtectionMiddleware` injected `_csrfToken`. 😉 

```php
if ($this->request->getParam('_csrfToken') === false) {
    $this->loadComponent('Csrf');
}
```