### PR TITLE
Extend CakePHP Migrations instead of Phinx

### DIFF
--- a/config/Migrations/20150513201111_initial.php
+++ b/config/Migrations/20150513201111_initial.php
@@ -9,7 +9,7 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class Initial extends AbstractMigration
 {


### PR DESCRIPTION
Utilize `src/Table.php` from CakePHP Migrations plugin, which has
extra functionality like setting default collation and encoding etc.

See this PR for more info: https://github.com/cakephp/migrations/pull/302

The above was merged to CakePHP Migrations v1.7.0.