### PR TITLE
Add default value for plugin param

### DIFF
--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -116,7 +116,7 @@ class UsersAuthComponent extends Component
         }
 
         list($plugin, $controller) = pluginSplit(Configure::read('Users.controller'));
-        if ($this->getController()->request->getParam('plugin') === $plugin &&
+        if ($this->getController()->request->getParam('plugin', null) === $plugin &&
             $this->getController()->request->getParam('controller') === $controller
         ) {
             $this->getController()->Auth->allow([


### PR DESCRIPTION
Hi!

I use this plugin, but with my own users controller (using the LoginTrait and RegisterTrait). I also have the UserAuthComponent added to my AppController, and I changed the configuration in users.php to point to my controller:
```
    'Users.controller' => 'Users',
```

However, the register page keeps telling me I'm not authorized to access it. 

I did some digging and I think this line is to blame. ``pluginSplit`` returns ``null`` by default. ``request->getParam('plugin')`` returns ``false`` by default. Those values do not match, which is why ``Auth->allow`` is never executed and I cannot access the register page.