### PR TITLE
Error when user cannot be saved after triggered beforeRegister event

### DIFF
--- a/src/Controller/Traits/RegisterTrait.php
+++ b/src/Controller/Traits/RegisterTrait.php
@@ -68,6 +68,7 @@ trait RegisterTrait
             } else {
                 $this->set(compact('user'));
                 $this->Flash->error(__d('CakeDC/Users', 'The user could not be saved'));
+
                 return;
             }
         }

--- a/src/Controller/Traits/RegisterTrait.php
+++ b/src/Controller/Traits/RegisterTrait.php
@@ -65,6 +65,10 @@ trait RegisterTrait
         if ($event->result instanceof EntityInterface) {
             if ($userSaved = $usersTable->register($user, $event->result->toArray(), $options)) {
                 return $this->_afterRegister($userSaved);
+            } else {
+                $this->set(compact('user'));
+                $this->Flash->error(__d('CakeDC/Users', 'The user could not be saved'));
+                return;
             }
         }
         if ($event->isStopped()) {

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -13,6 +13,7 @@ namespace CakeDC\Users\Test\TestCase\Controller\Traits;
 
 use Cake\Event\Event;
 use Cake\Mailer\Email;
+use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use PHPUnit_Framework_MockObject_RuntimeException;
@@ -200,12 +201,17 @@ abstract class BaseTraitTest extends TestCase
      * mock utility
      *
      * @param Event $event event
+     * @param array $result array of data
      * @return void
      */
-    protected function _mockDispatchEvent(Event $event = null)
+    protected function _mockDispatchEvent(Event $event = null, $result = [])
     {
         if (is_null($event)) {
             $event = new Event('cool-name-here');
+        }
+
+        if (!empty($result)) {
+            $event->result = new Entity($result);
         }
         $this->Trait->expects($this->any())
                 ->method('dispatchEvent')

--- a/tests/TestCase/Controller/Traits/RegisterTraitTest.php
+++ b/tests/TestCase/Controller/Traits/RegisterTraitTest.php
@@ -11,10 +11,10 @@
 
 namespace CakeDC\Users\Test\TestCase\Controller\Traits;
 
-use Cake\Event\Event;
 use CakeDC\Users\Test\TestCase\Controller\Traits\BaseTraitTest;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Event\Event;
 use Cake\Mailer\Email;
 use Cake\ORM\TableRegistry;
 


### PR DESCRIPTION
When beforeRegister event was being triggered, in case of any error trying to register, it was trying to register again the user instead of return with the errors. 