### PR TITLE
respect configured username field when searching for user during 'Forgot PW' request

### DIFF
--- a/src/Model/Behavior/PasswordBehavior.php
+++ b/src/Model/Behavior/PasswordBehavior.php
@@ -92,12 +92,22 @@ class PasswordBehavior extends BaseTokenBehavior
     /**
      * Get the user by email or username
      *
-     * @param string $reference reference could be either an email or username
+     * @param string $reference reference could be either an email or configured username field
      * @return mixed user entity if found
      */
     protected function _getUser($reference)
     {
-        return $this->_table->findByUsernameOrEmail($reference, $reference)->first();
+        $options = ['email' => $reference];
+
+        $userNameField = Configure::read('Auth.authenticate.Form.fields.username');
+
+        if (!empty($userNameField)) {
+            $options[$userNameField] = $reference;
+        }
+
+        return $this->_table->find()
+            ->where(['OR' => $options])
+            ->first();
     }
 
     /**


### PR DESCRIPTION
Reported in [Issue 511](https://github.com/CakeDC/users/issues/511)

Prevents an error from being thrown if users table doesn't contain a username column (for example, if 'email' is being used as the username).

I intend to follow up to add a test or two once i figure out a good test strategy using the existing fixtures.