### PR TITLE
Fix two factor auth only working on the second try.

### DIFF
--- a/src/Controller/Traits/LoginTrait.php
+++ b/src/Controller/Traits/LoginTrait.php
@@ -240,6 +240,8 @@ trait LoginTrait
                         ->set(['secret' => $secret])
                         ->where(['id' => $temporarySession['id']]);
                     $query->execute();
+
+                    $this->request->getSession()->write('temporarySession.secret', $secret);
                 } catch (\Exception $e) {
                     $this->request->getSession()->destroy();
                     $message = $e->getMessage();

--- a/src/Controller/Traits/LoginTrait.php
+++ b/src/Controller/Traits/LoginTrait.php
@@ -275,10 +275,12 @@ trait LoginTrait
                         ->set(['secret_verified' => true])
                         ->where(['id' => $user['id']])
                         ->execute();
+
+                    $user['secret_verified'] = true;
                 }
 
                 $this->request->getSession()->delete('temporarySession');
-                $this->request->getSession()->write('Auth.User', $user);
+                $this->Auth->setUser($user);
                 $url = $this->Auth->redirectUrl();
 
                 return $this->redirect($url);

--- a/tests/TestCase/Controller/Traits/LoginTraitTest.php
+++ b/tests/TestCase/Controller/Traits/LoginTraitTest.php
@@ -486,9 +486,121 @@ class LoginTraitTest extends BaseTraitTest
     }
 
     /**
+     * Tests that a GET request causes a a new secret to be generated in case it's
+     * not already present in the session.
+     */
+    public function testVerifyGetGeneratesNewSecret()
+    {
+        Configure::write('Users.GoogleAuthenticator.login', true);
+
+        $this->Trait->GoogleAuthenticator = $this
+            ->getMockBuilder(GoogleAuthenticatorComponent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['createSecret', 'getQRCodeImageAsDataUri'])
+            ->getMock();
+
+        $this->Trait->request = $this
+            ->getMockBuilder(ServerRequest::class)
+            ->setMethods(['is', 'getData', 'allow', 'getSession'])
+            ->getMock();
+        $this->Trait->request
+            ->expects($this->once())
+            ->method('is')
+            ->with('post')
+            ->will($this->returnValue(false));
+
+        $this->Trait->GoogleAuthenticator
+            ->expects($this->at(0))
+            ->method('createSecret')
+            ->will($this->returnValue('newSecret'));
+        $this->Trait->GoogleAuthenticator
+            ->expects($this->at(1))
+            ->method('getQRCodeImageAsDataUri')
+            ->with('email@example.com', 'newSecret')
+            ->will($this->returnValue('newDataUriGenerated'));
+
+        $session = $this->_mockSession([
+            'temporarySession' => [
+                'id' => '00000000-0000-0000-0000-000000000001',
+                'email' => 'email@example.com',
+                'secret_verified' => false,
+            ]
+        ]);
+        $this->Trait->verify();
+
+        $this->assertEquals(
+            [
+                'temporarySession' => [
+                    'id' => '00000000-0000-0000-0000-000000000001',
+                    'email' => 'email@example.com',
+                    'secret_verified' => false,
+                    'secret' => 'newSecret'
+                ]
+            ],
+            $session->read()
+        );
+    }
+
+    /**
+     * Tests that a GET request does not cause a new secret to be generated in case
+     * it's already present in the session.
+     */
+    public function testVerifyGetDoesNotGenerateNewSecret()
+    {
+        Configure::write('Users.GoogleAuthenticator.login', true);
+
+        $this->Trait->GoogleAuthenticator = $this
+            ->getMockBuilder(GoogleAuthenticatorComponent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['createSecret', 'getQRCodeImageAsDataUri'])
+            ->getMock();
+
+        $this->Trait->request = $this
+            ->getMockBuilder(ServerRequest::class)
+            ->setMethods(['is', 'getData', 'allow', 'getSession'])
+            ->getMock();
+        $this->Trait->request
+            ->expects($this->once())
+            ->method('is')
+            ->with('post')
+            ->will($this->returnValue(false));
+
+        $this->Trait->GoogleAuthenticator
+            ->expects($this->never())
+            ->method('createSecret');
+        $this->Trait->GoogleAuthenticator
+            ->expects($this->at(0))
+            ->method('getQRCodeImageAsDataUri')
+            ->with('email@example.com', 'alreadyPresentSecret')
+            ->will($this->returnValue('newDataUriGenerated'));
+
+        $session = $this->_mockSession([
+            'temporarySession' => [
+                'id' => '00000000-0000-0000-0000-000000000001',
+                'email' => 'email@example.com',
+                'secret_verified' => false,
+                'secret' => 'alreadyPresentSecret'
+            ]
+        ]);
+        $this->Trait->verify();
+
+        $this->assertEquals(
+            [
+                'temporarySession' => [
+                    'id' => '00000000-0000-0000-0000-000000000001',
+                    'email' => 'email@example.com',
+                    'secret_verified' => false,
+                    'secret' => 'alreadyPresentSecret'
+                ]
+            ],
+            $session->read()
+        );
+    }
+
+    /**
      * Mock session and mock session attributes
      *
-     * @return void
+     * @return \Cake\Http\Session
      */
     protected function _mockSession($attributes)
     {
@@ -502,5 +614,7 @@ class LoginTraitTest extends BaseTraitTest
             ->expects($this->any())
             ->method('getSession')
             ->willReturn($session);
+
+        return $session;
     }
 }


### PR DESCRIPTION
When no secret is set for a user, a new one is being generated and stored in the user record, however it's not being set in the session, so that on the subsequent POST request the secret is still not there, and a new one is being generated, which causes the verification to use the wrong secret.

After such a failed attempt the secret is present in the user record and will be fetched in `LoginTrait::_afterIdentifyUser()`, making it available in the session data so that no new secret is being generated, and the verification works.