### PR TITLE
CakePHP 3.7 Deprecation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It covers the following features:
 * Remember me (Cookie) via https://github.com/CakeDC/auth
 * Manage user's profile
 * Admin management
-* Yubico U2F for Two-Factor Authentication
+* Yubico U2F for Two-Factor Authentication 
 * One-Time Password for Two-Factor Authentication
 
 The plugin is here to provide users related features following 2 approaches:

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "source": "https://github.com/CakeDC/users"
     },
     "require": {
-        "cakephp/cakephp": "~3.6.0",
-        "cakedc/auth": "~3.0.0"
+        "cakephp/cakephp": "^3.7",
+        "cakedc/auth": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "league/oauth2-linkedin": "@stable",
         "luchianenco/oauth2-amazon": "^1.1",
         "google/recaptcha": "@stable",
-        "robthree/twofactorauth": "~1.6.0",
+        "robthree/twofactorauth": "~1.6",
         "yubico/u2flib-server": "^1.0"
     },
     "suggest": {

--- a/src/Auth/Social/Mapper/Cognito.php
+++ b/src/Auth/Social/Mapper/Cognito.php
@@ -19,7 +19,7 @@ use Cake\Utility\Hash;
  */
 class Cognito extends AbstractMapper
 {
-    
+
     /**
      * Map for provider fields
      * @var
@@ -49,7 +49,7 @@ class Cognito extends AbstractMapper
     {
         return Hash::get($this->_rawData, $this->_mapFields['first_name'], Hash::get(explode(' ', Hash::get($this->_rawData, 'name', '')), 0));
     }
-    
+
     /**
      * @return mixed
      */
@@ -57,5 +57,4 @@ class Cognito extends AbstractMapper
     {
         return Hash::get($this->_rawData, $this->_mapFields['last_name'], Hash::get(explode(' ', Hash::get($this->_rawData, 'name', '')), 1));
     }
-        
 }

--- a/src/Mailer/UsersMailer.php
+++ b/src/Mailer/UsersMailer.php
@@ -57,7 +57,9 @@ class UsersMailer extends Mailer
         $this
             ->setTo($user['email'])
             ->setSubject($subject)
-            ->setViewVars($user->toArray())
+            ->setViewVars($user->toArray());
+        $this
+            ->viewBuilder()
             ->setTemplate('CakeDC/Users.resetPassword');
     }
 
@@ -77,7 +79,9 @@ class UsersMailer extends Mailer
         $this
             ->setTo($user['email'])
             ->setSubject($subject)
-            ->setViewVars(compact('user', 'socialAccount'))
+            ->setViewVars(compact('user', 'socialAccount'));
+        $this
+            ->viewBuilder()
             ->setTemplate('CakeDC/Users.socialAccountValidation');
     }
 }

--- a/src/Mailer/UsersMailer.php
+++ b/src/Mailer/UsersMailer.php
@@ -32,10 +32,12 @@ class UsersMailer extends Mailer
         $user->setHidden(['password', 'token_expires', 'api_token']);
         $subject = __d('CakeDC/Users', 'Your account validation link');
         $this
-            ->setTo($user['email'])
+             ->setTo($user['email'])
              ->setSubject($firstName . $subject)
-             ->setViewVars($user->toArray())
-             ->setTemplate('CakeDC/Users.validation');
+             ->setViewVars($user->toArray());
+
+        $this
+            ->viewBuilder()->setTemplate('CakeDC/Users.validation');
     }
 
     /**

--- a/src/View/Helper/UserHelper.php
+++ b/src/View/Helper/UserHelper.php
@@ -108,13 +108,13 @@ class UserHelper extends Helper
      */
     public function welcome()
     {
-        $userId = $this->request->getSession()->read('Auth.User.id');
+        $userId = $this->getView()->getRequest()->getSession()->read('Auth.User.id');
         if (empty($userId)) {
             return;
         }
 
         $profileUrl = Configure::read('Users.Profile.route');
-        $label = __d('CakeDC/Users', 'Welcome, {0}', $this->AuthLink->link($this->request->getSession()->read('Auth.User.first_name') ?: $this->request->getSession()->read('Auth.User.username'), $profileUrl));
+        $label = __d('CakeDC/Users', 'Welcome, {0}', $this->AuthLink->link($this->getView()->getRequest()->getSession()->read('Auth.User.first_name') ?: $this->request->getSession()->read('Auth.User.username'), $profileUrl));
 
         return $this->Html->tag('span', $label, ['class' => 'welcome']);
     }

--- a/tests/TestCase/Auth/SocialAuthenticateTest.php
+++ b/tests/TestCase/Auth/SocialAuthenticateTest.php
@@ -34,8 +34,8 @@ class SocialAuthenticateTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Controller/Component/GoogleAuthenticatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/GoogleAuthenticatorComponentTest.php
@@ -31,7 +31,7 @@ use Cake\Utility\Security;
 class GoogleAuthenticatorComponentTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Controller/Component/RememberMeComponentTest.php
+++ b/tests/TestCase/Controller/Component/RememberMeComponentTest.php
@@ -26,7 +26,7 @@ use InvalidArgumentException;
 class RememberMeComponentTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.Users'
     ];
     /**
      * setUp method

--- a/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/UsersAuthComponentTest.php
@@ -39,7 +39,7 @@ class UsersAuthComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Controller/SocialAccountsControllerTest.php
+++ b/tests/TestCase/Controller/SocialAccountsControllerTest.php
@@ -29,8 +29,8 @@ class SocialAccountsControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Controller/SocialAccountsControllerTest.php
+++ b/tests/TestCase/Controller/SocialAccountsControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace CakeDC\Users\Test\TestCase\Controller;
 
+use Cake\Mailer\TransportFactory;
 use CakeDC\Users\Controller\SocialAccountsController;
 use CakeDC\Users\Model\Behavior\SocialAccountBehavior;
 use CakeDC\Users\Model\Table\SocialAccountsTable;
@@ -47,9 +48,7 @@ class SocialAccountsControllerTest extends TestCase
         Configure::write('Opauth', null);
         Configure::write('Users.RememberMe.active', false);
 
-        Email::setConfigTransport('test', [
-            'className' => 'Debug'
-        ]);
+        TransportFactory::setConfig('test', ['className' => 'Debug']);
         $this->configEmail = Email::getConfig('default');
         Email::drop('default');
         Email::setConfig('default', [
@@ -77,7 +76,7 @@ class SocialAccountsControllerTest extends TestCase
     public function tearDown()
     {
         Email::drop('default');
-        Email::dropTransport('test');
+        TransportFactory::drop('test');
         //Email::setConfig('default', $this->configEmail);
 
         Configure::write('Opauth', $this->configOpauth);

--- a/tests/TestCase/Controller/SocialAccountsControllerTest.php
+++ b/tests/TestCase/Controller/SocialAccountsControllerTest.php
@@ -11,15 +11,10 @@
 
 namespace CakeDC\Users\Test\TestCase\Controller;
 
-use Cake\Mailer\TransportFactory;
-use CakeDC\Users\Controller\SocialAccountsController;
-use CakeDC\Users\Model\Behavior\SocialAccountBehavior;
-use CakeDC\Users\Model\Table\SocialAccountsTable;
 use Cake\Core\Configure;
-use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use Cake\Mailer\Email;
-use Cake\Network\Request;
+use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
 
 class SocialAccountsControllerTest extends TestCase

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -26,7 +26,7 @@ abstract class BaseTraitTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Controller/Traits/BaseTraitTest.php
+++ b/tests/TestCase/Controller/Traits/BaseTraitTest.php
@@ -13,6 +13,7 @@ namespace CakeDC\Users\Test\TestCase\Controller\Traits;
 
 use Cake\Event\Event;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -61,9 +62,7 @@ abstract class BaseTraitTest extends TestCase
         }
 
         if ($this->mockDefaultEmail) {
-            Email::setConfigTransport('test', [
-                'className' => 'Debug'
-            ]);
+            TransportFactory::setConfig('test', ['className' => 'Debug']);
             $this->configEmail = Email::getConfig('default');
             Email::drop('default');
             Email::setConfig('default', [
@@ -83,7 +82,7 @@ abstract class BaseTraitTest extends TestCase
         unset($this->table, $this->Trait);
         if ($this->mockDefaultEmail) {
             Email::drop('default');
-            Email::dropTransport('test');
+            TransportFactory::drop('test');
             //Email::setConfig('default', $this->setConfigEmail);
         }
         parent::tearDown();

--- a/tests/TestCase/Controller/Traits/LinkSocialTraitTest.php
+++ b/tests/TestCase/Controller/Traits/LinkSocialTraitTest.php
@@ -38,8 +38,8 @@ class LinkSocialTraitTest extends BaseTraitTest
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Controller/Traits/ProfileTraitTest.php
+++ b/tests/TestCase/Controller/Traits/ProfileTraitTest.php
@@ -23,8 +23,8 @@ class ProfileTraitTest extends BaseTraitTest
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.CakeDC/Users.social_accounts',
+        'plugin.CakeDC/Users.Users',
+        'plugin.CakeDC/Users.SocialAccounts',
     ];
 
     /**

--- a/tests/TestCase/Controller/Traits/U2fTraitTest.php
+++ b/tests/TestCase/Controller/Traits/U2fTraitTest.php
@@ -32,7 +32,7 @@ class U2fTraitTest extends BaseTraitTest
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
     /**
      * setup

--- a/tests/TestCase/Mailer/UsersMailerTest.php
+++ b/tests/TestCase/Mailer/UsersMailerTest.php
@@ -26,8 +26,8 @@ class UsersMailerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/AuthFinderBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AuthFinderBehaviorTest.php
@@ -32,7 +32,7 @@ class AuthFinderBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/LinkSocialBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LinkSocialBehaviorTest.php
@@ -36,8 +36,8 @@ class LinkSocialBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
@@ -11,11 +11,11 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
-use Cake\Mailer\TransportFactory;
 use CakeDC\Users\Model\Behavior\PasswordBehavior;
 use CakeDC\Users\Test\App\Mailer\OverrideMailer;
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;

--- a/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
@@ -11,6 +11,7 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
+use Cake\Mailer\TransportFactory;
 use CakeDC\Users\Model\Behavior\PasswordBehavior;
 use CakeDC\Users\Test\App\Mailer\OverrideMailer;
 use Cake\Core\Configure;
@@ -47,9 +48,8 @@ class PasswordBehaviorTest extends TestCase
                 ->setMethods(['_sendResetPasswordEmail'])
                 ->setConstructorArgs([$this->table])
                 ->getMock();
-        Email::setConfigTransport('test', [
-            'className' => 'Debug'
-        ]);
+        TransportFactory::drop('test');
+        TransportFactory::setConfig('test', ['className' => 'Debug']);
         //$this->configEmail = Email::getConfig('default');
         Email::setConfig('default', [
             'transport' => 'test',
@@ -66,7 +66,7 @@ class PasswordBehaviorTest extends TestCase
     {
         unset($this->table, $this->Behavior);
         Email::drop('default');
-        Email::dropTransport('test');
+        TransportFactory::drop('test');
         parent::tearDown();
     }
 

--- a/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
@@ -31,7 +31,7 @@ class PasswordBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -12,10 +12,9 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
-use Cake\Mailer\TransportFactory;
-use CakeDC\Users\Exception\UserAlreadyActiveException;
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -12,6 +12,7 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
+use Cake\Mailer\TransportFactory;
 use CakeDC\Users\Exception\UserAlreadyActiveException;
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
@@ -45,9 +46,7 @@ class RegisterBehaviorTest extends TestCase
         $table->addBehavior('CakeDC/Users/Register.Register');
         $this->Table = $table;
         $this->Behavior = $table->behaviors()->Register;
-        Email::setConfigTransport('test', [
-            'className' => 'Debug'
-        ]);
+        TransportFactory::setConfig('test', ['className' => 'Debug']);
         Email::setConfig('default', [
             'transport' => 'test',
             'from' => 'cakedc@example.com'
@@ -63,7 +62,7 @@ class RegisterBehaviorTest extends TestCase
     {
         unset($this->Table, $this->Behavior);
         Email::drop('default');
-        Email::dropTransport('test');
+        TransportFactory::drop('test');
         parent::tearDown();
     }
 

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -30,7 +30,7 @@ class RegisterBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/SocialAccountBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SocialAccountBehaviorTest.php
@@ -30,8 +30,8 @@ class SocialAccountBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/SocialAccountBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SocialAccountBehaviorTest.php
@@ -13,11 +13,8 @@ namespace CakeDC\Users\Test\TestCase\Model\Behavior;
 
 use CakeDC\Users\Model\Table\SocialAccountsTable;
 use Cake\Event\Event;
-use Cake\Mailer\Email;
 use Cake\ORM\TableRegistry;
-use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 
 /**
  * Test Case

--- a/tests/TestCase/Model/Behavior/SocialBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SocialBehaviorTest.php
@@ -24,8 +24,8 @@ class SocialBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SocialAccountsTableTest.php
+++ b/tests/TestCase/Model/Table/SocialAccountsTableTest.php
@@ -31,8 +31,8 @@ class SocialAccountsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.social_accounts',
-        'plugin.CakeDC/Users.users'
+        'plugin.CakeDC/Users.SocialAccounts',
+        'plugin.CakeDC/Users.Users'
     ];
 
     /**

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -11,17 +11,12 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Table;
 
-use Cake\Mailer\TransportFactory;
-use CakeDC\Users\Exception\AccountNotActiveException;
-use CakeDC\Users\Exception\UserAlreadyActiveException;
-use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Model\Table\SocialAccountsTable;
-use Cake\Core\Plugin;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
 use InvalidArgumentException;
 
 /**

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -34,8 +34,8 @@ class UsersTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.CakeDC/Users.social_accounts'
+        'plugin.CakeDC/Users.Users',
+        'plugin.CakeDC/Users.SocialAccounts'
     ];
 
     /**

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -11,6 +11,7 @@
 
 namespace CakeDC\Users\Test\TestCase\Model\Table;
 
+use Cake\Mailer\TransportFactory;
 use CakeDC\Users\Exception\AccountNotActiveException;
 use CakeDC\Users\Exception\UserAlreadyActiveException;
 use CakeDC\Users\Exception\UserNotFoundException;
@@ -49,9 +50,8 @@ class UsersTableTest extends TestCase
         $this->Users = TableRegistry::getTableLocator()->get('CakeDC/Users.Users');
         $this->fullBaseBackup = Router::fullBaseUrl();
         Router::fullBaseUrl('http://users.test');
-        Email::setConfigTransport('test', [
-            'className' => 'Debug'
-        ]);
+        TransportFactory::drop('test');
+        TransportFactory::setConfig('test', ['className' => 'Debug']);
         Email::setConfig('default', [
             'transport' => 'test',
             'from' => 'cakedc@example.com'
@@ -68,7 +68,6 @@ class UsersTableTest extends TestCase
         unset($this->Users);
         Router::fullBaseUrl($this->fullBaseBackup);
         Email::drop('default');
-        Email::dropTransport('test');
 
         parent::tearDown();
     }

--- a/tests/TestCase/Shell/UsersShellTest.php
+++ b/tests/TestCase/Shell/UsersShellTest.php
@@ -25,8 +25,8 @@ class UsersShellTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.CakeDC/Users.social_accounts',
+        'plugin.CakeDC/Users.Users',
+        'plugin.CakeDC/Users.SocialAccounts',
     ];
 
     /**

--- a/tests/TestCase/View/Helper/UserHelperTest.php
+++ b/tests/TestCase/View/Helper/UserHelperTest.php
@@ -143,10 +143,11 @@ class UserHelperTest extends TestCase
             ->with('Auth.User.first_name')
             ->will($this->returnValue('david'));
 
-        $this->User->request = $this->getMockBuilder('Cake\Network\Request')
+        $request = $this->getMockBuilder('Cake\Network\Request')
                 ->setMethods(['getSession'])
                 ->getMock();
-        $this->User->request->expects($this->any())
+        $this->User->getView()->setRequest($request);
+        $this->User->getView()->getRequest()->expects($this->any())
             ->method('getSession')
             ->will($this->returnValue($session));
 
@@ -170,10 +171,11 @@ class UserHelperTest extends TestCase
             ->with('Auth.User.id')
             ->will($this->returnValue(null));
 
-        $this->User->request = $this->getMockBuilder('Cake\Network\Request')
+        $request = $this->getMockBuilder('Cake\Network\Request')
                 ->setMethods(['getSession'])
                 ->getMock();
-        $this->User->request->expects($this->any())
+        $this->User->getView()->setRequest($request);
+        $this->User->getView()->getRequest()->expects($this->any())
             ->method('getSession')
             ->will($this->returnValue($session));
 


### PR DESCRIPTION
Fixes all CakePHP 3.7 Deprecations. 

There is one left that is Plugin::load() but this only effects testing