### PR TITLE
Add support to specify scope on social login

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -152,7 +152,7 @@ $config = [
         'providers' => [
             'facebook' => [
                 'className' => 'League\OAuth2\Client\Provider\Facebook',
-                'scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link'],
+                'authScope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link'],
                 'options' => [
                     'graphApiVersion' => 'v2.8', //bio field was deprecated on >= v2.8
                     'redirectUri' => Router::fullBaseUrl() . '/auth/facebook',

--- a/config/users.php
+++ b/config/users.php
@@ -152,6 +152,7 @@ $config = [
         'providers' => [
             'facebook' => [
                 'className' => 'League\OAuth2\Client\Provider\Facebook',
+                'scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link'],
                 'options' => [
                     'graphApiVersion' => 'v2.8', //bio field was deprecated on >= v2.8
                     'redirectUri' => Router::fullBaseUrl() . '/auth/facebook',

--- a/src/Auth/SocialAuthenticate.php
+++ b/src/Auth/SocialAuthenticate.php
@@ -281,9 +281,9 @@ class SocialAuthenticate extends BaseAuthenticate
         if ($this->getConfig('options.state')) {
             $request->getSession()->write('oauth2state', $provider->getState());
         }
-        
+
         $options = [
-            'scope' => $this->getConfig(sprintf('providers.%s.scope', $request->getParam('provider')))
+            'scope' => $this->getConfig(sprintf('providers.%s.authScope', $request->getParam('provider')))
         ];
 
         $response = $response->withLocation($provider->getAuthorizationUrl($options));

--- a/src/Auth/SocialAuthenticate.php
+++ b/src/Auth/SocialAuthenticate.php
@@ -281,8 +281,12 @@ class SocialAuthenticate extends BaseAuthenticate
         if ($this->getConfig('options.state')) {
             $request->getSession()->write('oauth2state', $provider->getState());
         }
+        
+        $options = [
+            'scope' => $this->getConfig(sprintf('providers.%s.scope', $request->getParam('provider')))
+        ];
 
-        $response = $response->withLocation($provider->getAuthorizationUrl());
+        $response = $response->withLocation($provider->getAuthorizationUrl($options));
 
         return $response;
     }


### PR DESCRIPTION
This adds support to specify the scope option instead of always just using the default one given by the provider.