### PR TITLE
Fix authParams option not being parsed

### DIFF
--- a/src/Auth/SocialAuthenticate.php
+++ b/src/Auth/SocialAuthenticate.php
@@ -112,6 +112,7 @@ class SocialAuthenticate extends BaseAuthenticate
 
         $defaults = [
                 'className' => null,
+                'authParams' => [],
                 'options' => [],
                 'collaborators' => [],
                 'mapFields' => [],


### PR DESCRIPTION
Even if the `authParams` configuration option is set, it will not be loaded, unless this change is made.