### PR TITLE
Honor config option for username field

### DIFF
--- a/src/Auth/SocialAuthenticate.php
+++ b/src/Auth/SocialAuthenticate.php
@@ -368,11 +368,7 @@ class SocialAuthenticate extends BaseAuthenticate
             $this->_getController()->dispatchEvent(UsersAuthComponent::EVENT_AFTER_REGISTER, compact('user'));
         }
 
-        if (!empty($user->username)) {
-            $user = $this->_findUser($user->username);
-        }
-
-        return $user;
+        return $this->_findUser($user->get(Configure::read('Auth.authenticate.Form.fields.username', 'username')));
     }
 
     /**

--- a/src/Model/Behavior/SocialBehavior.php
+++ b/src/Model/Behavior/SocialBehavior.php
@@ -130,6 +130,7 @@ class SocialBehavior extends BaseTokenBehavior
 
         $event = $this->dispatchEvent(UsersAuthComponent::EVENT_BEFORE_SOCIAL_LOGIN_USER_CREATE, [
             'userEntity' => $user,
+            'data' => $data,
         ]);
         if ($event->result instanceof EntityInterface) {
             $user = $event->result;

--- a/src/Model/Behavior/SocialBehavior.php
+++ b/src/Model/Behavior/SocialBehavior.php
@@ -130,7 +130,6 @@ class SocialBehavior extends BaseTokenBehavior
 
         $event = $this->dispatchEvent(UsersAuthComponent::EVENT_BEFORE_SOCIAL_LOGIN_USER_CREATE, [
             'userEntity' => $user,
-            'data' => $data,
         ]);
         if ($event->result instanceof EntityInterface) {
             $user = $event->result;


### PR DESCRIPTION
Instead of using the `username` field, this checks the config.
Also, if the `$this->_findUser()` method is not called, the value returned will be a user entity instead of an array, causing the authentication to fail.