### PR TITLE
Allow overriding of find function for existing users

### DIFF
--- a/src/Auth/SocialAuthenticate.php
+++ b/src/Auth/SocialAuthenticate.php
@@ -284,10 +284,11 @@ class SocialAuthenticate extends BaseAuthenticate
         }
 
         $authParams = $this->getConfig(sprintf('providers.%s.authParams', $request->getParam('provider')), []);
+        $location = $provider->getAuthorizationUrl($authParams);
 
-        $response = $response->withLocation($provider->getAuthorizationUrl($authParams));
+        $this->dispatchEvent(UsersAuthComponent::EVENT_BEFORE_SOCIAL_LOGIN_REDIRECT, compact('location', 'request'));
 
-        return $response;
+        return $response->withLocation($location);
     }
 
     /**

--- a/src/Controller/Component/UsersAuthComponent.php
+++ b/src/Controller/Component/UsersAuthComponent.php
@@ -33,6 +33,7 @@ class UsersAuthComponent extends Component
     const EVENT_AFTER_REGISTER = 'Users.Component.UsersAuth.afterRegister';
     const EVENT_BEFORE_LOGOUT = 'Users.Component.UsersAuth.beforeLogout';
     const EVENT_AFTER_LOGOUT = 'Users.Component.UsersAuth.afterLogout';
+    const EVENT_BEFORE_SOCIAL_LOGIN_REDIRECT = 'Users.Component.UsersAuth.beforeSocialLoginRedirect';
     const EVENT_BEFORE_SOCIAL_LOGIN_USER_CREATE = 'Users.Component.UsersAuth.beforeSocialLoginUserCreate';
     const EVENT_AFTER_CHANGE_PASSWORD = 'Users.Component.UsersAuth.afterResetPassword';
     const EVENT_ON_EXPIRED_TOKEN = 'Users.Component.UsersAuth.onExpiredToken';

--- a/src/Controller/Traits/LinkSocialTrait.php
+++ b/src/Controller/Traits/LinkSocialTrait.php
@@ -15,6 +15,7 @@ use CakeDC\Users\Model\Table\SocialAccountsTable;
 use Cake\Core\Configure;
 use Cake\Http\Exception\NotFoundException;
 use League\OAuth1\Client\Server\Twitter;
+use CakeDC\Users\Controller\Component\UsersAuthComponent;
 
 /**
  * Ações para "linkar" contas sociais
@@ -40,6 +41,10 @@ trait LinkSocialTrait
             $this->request->getSession()->write('temporary_credentials', $temporaryCredentials);
         }
         $authUrl = $provider->getAuthorizationUrl($temporaryCredentials);
+        $this->dispatchEvent(UsersAuthComponent::EVENT_BEFORE_SOCIAL_LOGIN_REDIRECT, [
+            'location' =>$authUrl,
+            'request' => $this->getRequest(),
+        ]);
         if (empty($temporaryCredentials)) {
             $this->request->session()->write('SocialLink.oauth2state', $provider->getState());
         }

--- a/src/Model/Behavior/SocialBehavior.php
+++ b/src/Model/Behavior/SocialBehavior.php
@@ -121,9 +121,7 @@ class SocialBehavior extends BaseTokenBehavior
         if ($useEmail && empty($email)) {
             throw new MissingEmailException(__d('CakeDC/Users', 'Email not present'));
         } else {
-            $existingUser = $this->_table->find()
-                ->where([$this->_table->aliasField('email') => $email])
-                ->first();
+            $existingUser = $this->_table->find('existing', compact('email'))->first();
         }
 
         $user = $this->_populateUser($data, $existingUser, $useEmail, $validateEmail, $tokenExpiration);
@@ -257,5 +255,10 @@ class SocialBehavior extends BaseTokenBehavior
         }
 
         return $username;
+    }
+
+    public function findExisting(\Cake\ORM\Query $query, array $options)
+    {
+        return $query->where([$this->_table->aliasField('email') => $options['email']]);
     }
 }


### PR DESCRIPTION
Currently their is no way to customise the existing user check, for example we have a concept of "ghost users" and do not want these to be included in the results. I've added a finder for existing users that can easily be overridden.

I've also made a new event that gets dispatched right before the user gets redirected to the social account. This was quite useful for us, as we use it to validate the `state` variable, which is available only at this moment.