### PR TITLE
Unlock login action due to session renew after login

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -52,13 +52,7 @@ class UsersController extends AppController
         if ($this->components()->has('Security')) {
             $this->Security->setConfig(
                 'unlockedActions',
-                [
-                    'login',
-                    'u2fRegister',
-                    'u2fRegisterFinish',
-                    'u2fAuthenticate',
-                    'u2fAuthenticateFinish'
-                ]
+                ['login', 'u2fRegister', 'u2fRegisterFinish', 'u2fAuthenticate', 'u2fAuthenticateFinish']
             );
         }
     }

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -52,7 +52,13 @@ class UsersController extends AppController
         if ($this->components()->has('Security')) {
             $this->Security->setConfig(
                 'unlockedActions',
-                ['u2fRegister', 'u2fRegisterFinish', 'u2fAuthenticate', 'u2fAuthenticateFinish']
+                [
+                    'login',
+                    'u2fRegister',
+                    'u2fRegisterFinish',
+                    'u2fAuthenticate',
+                    'u2fAuthenticateFinish'
+                ]
             );
         }
     }


### PR DESCRIPTION
Per discussion here: https://github.com/cakephp/authentication/issues/284

Since the session needs to be renewed upon login, the `SecurityComponent` becomes incompatible with login forms in particular. We still have CSRF protection, are already checking for specific form fields, and are not writing to the database for the login process -- only reading. Unlocking the login action prevents a `Bad Request` error coming from `SecurityComponent`