### PR TITLE
Remove incorrect line in installation instructions

### DIFF
--- a/Docs/Documentation/Installation.md
+++ b/Docs/Documentation/Installation.md
@@ -70,7 +70,6 @@ class Application extends BaseApplication
 
         // Load a plugin with a vendor namespace by 'short name'
         $this->addPlugin('CakeDC/Users');
-        Configure::write('Users.config', ['users']);
     }
 }
 ```


### PR DESCRIPTION
The line `Configure::write('Users.config', ['users']);` is incorrectly mentioned in the documentation and causes error during installation, if the instructions are followed as mentioned in the documentation.
Ignoring this line (commenting/removing) ensures successful execution of this step, and enables the user to execute next step.