### PR TITLE
Use plugin routes

### DIFF
--- a/Docs/Documentation/Installation.md
+++ b/Docs/Documentation/Installation.md
@@ -69,7 +69,7 @@ class Application extends BaseApplication
         parent::bootstrap();
 
         // Load a plugin with a vendor namespace by 'short name'
-        $this->addPlugin('CakeDC/Users');
+        $this->addPlugin('CakeDC/Users', ['routes' => true]);
         Configure::write('Users.config', ['users']);
     }
 }


### PR DESCRIPTION
When the plugin in loaded, mark the routes for the plugin to be used by default.
This is to make sure that without any other user actions, the plugin works as expected #zeroConfiguration