### PR TITLE
Using `UsersUrl::actionUrl()` for redirects

### DIFF
--- a/src/Controller/Traits/RegisterTrait.php
+++ b/src/Controller/Traits/RegisterTrait.php
@@ -12,6 +12,7 @@
 namespace CakeDC\Users\Controller\Traits;
 
 use CakeDC\Users\Plugin;
+use CakeDC\Users\Utility\UsersUrl;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\NotFoundException;
@@ -142,7 +143,7 @@ trait RegisterTrait
         }
         $this->Flash->success($message);
 
-        return $this->redirect(['action' => 'login']);
+        return $this->redirect(UsersUrl::actionUrl('login'));
     }
 
     /**

--- a/src/Controller/Traits/UserValidationTrait.php
+++ b/src/Controller/Traits/UserValidationTrait.php
@@ -15,6 +15,7 @@ use CakeDC\Users\Exception\TokenExpiredException;
 use CakeDC\Users\Exception\UserAlreadyActiveException;
 use CakeDC\Users\Exception\UserNotFoundException;
 use CakeDC\Users\Plugin;
+use CakeDC\Users\Utility\UsersUrl;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Exception;
@@ -58,7 +59,7 @@ trait UserValidationTrait
                             $result->id
                         );
 
-                        return $this->redirect(['action' => 'changePassword']);
+                        return $this->redirect(UsersUrl::actionUrl('changePassword'));
                     } else {
                         $this->Flash->error(__d('cake_d_c/users', 'Reset password token could not be validated'));
                     }
@@ -76,7 +77,7 @@ trait UserValidationTrait
             $this->Flash->error(__d('cake_d_c/users', 'Token already expired'));
         }
 
-        return $this->redirect(['action' => 'login']);
+        return $this->redirect(UsersUrl::actionUrl('login'));
     }
 
     /**
@@ -111,7 +112,7 @@ trait UserValidationTrait
                 $this->Flash->error(__d('cake_d_c/users', 'Token could not be reset'));
             }
 
-            return $this->redirect(['action' => 'login']);
+            return $this->redirect(UsersUrl::actionUrl('login'));
         } catch (UserNotFoundException $ex) {
             $this->Flash->error(__d('cake_d_c/users', 'User {0} was not found', $reference));
         } catch (UserAlreadyActiveException $ex) {


### PR DESCRIPTION
This seems to be the right pattern for the login action. After verifying email, it wasn't redirecting to the default `/login` URL, instead to `/users/login`

I tried using the Change Password link as well... Using `UsersUrl::actionUrl()`, it seems to work fine. It redirects to `/users/change-password` and the flow seems operational.

Hopefully this is on the right track