### PR TITLE
Update cakephp/cakephp-codesniffer branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "yubico/u2flib-server": "^1.0",
         "php-coveralls/php-coveralls": "^2.1",
         "league/oauth1-client": "^1.7",
-        "cakephp/cakephp-codesniffer": "dev-next"
+        "cakephp/cakephp-codesniffer": "dev-master"
     },
     "suggest": {
         "league/oauth1-client": "Provides Social Authentication with Twitter",

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -319,9 +319,6 @@ class PluginTest extends TestCase
         }
         $this->assertEquals($expected, $actual);
 
-        /**
-         * @var \Authentication\Authenticator\AuthenticatorCollection $authenticators
-         */
         $identifiers = $service->identifiers();
         $expected = [
             PasswordIdentifier::class => [


### PR DESCRIPTION
Hi !

I fork the project and create a pull request for a new feature.
On the branch develop, i was able to do a `composer run check` without errors.

I rebase the branch on 9.next and fix somes conflicts but now I can't do a `composer install`.


On Composer Install : 
`Problem 1
    - The requested package cakephp/cakephp-codesniffer dev-next exists as cakephp/cakephp-codesniffer[0.1.24, 0.1.25, 0.1.26, 0.1.27, 0.1.28, 0.1.29, 0.1.30, 0.1.31, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.x-dev, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.5, 2.2.0, 2.3.0, 2.4.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.2.1, 3.3.0, 3.x-dev, 4.0.0, 4.0.0-beta1, 4.0.0-beta2, 4.0.0-beta3, 4.0.0-beta4, 4.0.0-beta5, dev-checks-travis, dev-dakota-patch-1, dev-master, dev-updates] but these are rejected by your constraint.`

In the composer.json file : 
`"cakephp/cakephp-codesniffer": "dev-next"`

The branch `next` cannot be found, even on the repo https://github.com/cakephp/cakephp-codesniffer

This branch was deleted the December 16 2019.
https://github.com/cakephp/cakephp-codesniffer/issues/239#issuecomment-565938909
> I think this can be closed. The ruleset we have now is good enough. I have already merged `next` into `master` and it's ready for tagging.

I wonder, how the travis Ci realise successfull test yesterday : 
https://travis-ci.org/CakeDC/users/builds/636885329?utm_medium=notification&utm_source=github_status
(maybe with the cache ?)


