### PR TITLE
Use newEmptyEntity() instead of newEntity([])

### DIFF
--- a/src/Controller/Traits/RegisterTrait.php
+++ b/src/Controller/Traits/RegisterTrait.php
@@ -50,7 +50,7 @@ trait RegisterTrait
         }
 
         $usersTable = $this->getUsersTable();
-        $user = $usersTable->newEntity([]);
+        $user = $usersTable->newEmptyEntity();
         $validateEmail = (bool)Configure::read('Users.Email.validate');
         $useTos = (bool)Configure::read('Users.Tos.required');
         $tokenExpiration = Configure::read('Users.Token.expiration');

--- a/src/Controller/Traits/SimpleCrudTrait.php
+++ b/src/Controller/Traits/SimpleCrudTrait.php
@@ -64,7 +64,7 @@ trait SimpleCrudTrait
     {
         $table = $this->loadModel();
         $tableAlias = $table->getAlias();
-        $entity = $table->newEntity([]);
+        $entity = $table->newEmptyEntity();
         $this->set($tableAlias, $entity);
         $this->set('tableAlias', $tableAlias);
         $this->set('_serialize', [$tableAlias, 'tableAlias']);


### PR DESCRIPTION
This allow forms validation message to be outputed only if fields are wrong and only after being submitted. 