### PR TITLE
Fixing issue with RememberMe/CookieAuth cookie

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -92,7 +92,7 @@ $config = [
             'Cookie' => [
                 'name' => 'remember_me',
                 'Config' => [
-                    'expire' => new DateTime('+1 month'),
+                    'expire' => new \DateTime('+1 month'),
                     'httpOnly' => true,
                 ]
             ]
@@ -150,7 +150,7 @@ $config = [
                 'skipTwoFactorVerify' => true,
                 'rememberMeField' => 'remember_me',
                 'cookie' => [
-                    'expire' => new DateTime('+1 month'),
+                    'expire' => new \DateTime('+1 month'),
                     'httpOnly' => true,
                 ],
                 'urlChecker' => 'Authentication.CakeRouter',

--- a/config/users.php
+++ b/config/users.php
@@ -92,7 +92,7 @@ $config = [
             'Cookie' => [
                 'name' => 'remember_me',
                 'Config' => [
-                    'expires' => '1 month',
+                    'expire' => new DateTime('+1 month'),
                     'httpOnly' => true,
                 ]
             ]
@@ -150,7 +150,7 @@ $config = [
                 'skipTwoFactorVerify' => true,
                 'rememberMeField' => 'remember_me',
                 'cookie' => [
-                    'expires' => '1 month',
+                    'expire' => new DateTime('+1 month'),
                     'httpOnly' => true,
                 ],
                 'urlChecker' => 'Authentication.CakeRouter',


### PR DESCRIPTION
Remember me cookie would expire at the end of session because the expected parameter was `expire` and the config file has `expires` so cookies would expire at the end of the session.