### PR TITLE
Allow a string or UriComponent to also be passed for redirect.

### DIFF
--- a/src/Controller/Component/LoginComponent.php
+++ b/src/Controller/Component/LoginComponent.php
@@ -21,6 +21,7 @@ use CakeDC\Auth\Authentication\AuthenticationService;
 use CakeDC\Auth\Traits\IsAuthorizedTrait;
 use CakeDC\Users\Plugin;
 use CakeDC\Users\Utility\UsersUrl;
+use Psr\Http\Message\UriInterface;
 
 /**
  * LoginFailure component
@@ -145,7 +146,7 @@ class LoginComponent extends Component
     protected function afterIdentifyUser($user)
     {
         $event = $this->getController()->dispatchEvent(Plugin::EVENT_AFTER_LOGIN, ['user' => $user]);
-        if (is_array($event->getResult())) {
+        if (is_array($event->getResult()) || is_string($event->getResult()) || $event->getResult() instanceof UriInterface) {
             return $this->getController()->redirect($event->getResult());
         }
 


### PR DESCRIPTION
This allows the result of the AFTER_LOGIN event to also be a string or `UriComponent`, As the `redirect()` method the result is passed to supports all of these. But it will currently only pass it to `redirect()` if it is an array. I wasn't sure which branch to really target for this. Let me know if I should change it.