### PR TITLE
Update users.php

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -92,8 +92,8 @@ $config = [
             'Cookie' => [
                 'name' => 'remember_me',
                 'Config' => [
-                    'expire' => new \DateTime('+1 month'),
-                    'httpOnly' => true,
+                    'expires' => new \DateTime('+1 month'),
+                    'httponly' => true,
                 ]
             ]
         ],
@@ -150,8 +150,8 @@ $config = [
                 'skipTwoFactorVerify' => true,
                 'rememberMeField' => 'remember_me',
                 'cookie' => [
-                    'expire' => new \DateTime('+1 month'),
-                    'httpOnly' => true,
+                    'expires' => new \DateTime('+1 month'),
+                    'httponly' => true,
                 ],
                 'urlChecker' => 'Authentication.CakeRouter',
             ],


### PR DESCRIPTION
I get deprication warnings when trying to log out.

Config key `expire` is deprecated, use `expires` instead. - /var/www/html/vendor/cakephp/authentication/src/Authenticator/CookieAuthenticator.php
Config key `httpOnly` is deprecated, use `httponly` instead. - /var/www/html/vendor/cakephp/authentication/src/Authenticator/CookieAuthenticator.php

Changing these values fixes the issue for me
Currently running CakePHP 4.1.7