### PR TITLE
Updated doc `Using the user's email to login`

### DIFF
--- a/Docs/Documentation/Configuration.md
+++ b/Docs/Documentation/Configuration.md
@@ -174,6 +174,7 @@ user identify. Add this to your config/users.php:
 ```php
 'Auth.Identifiers.Password.fields.username' => 'email',
 'Auth.Authenticators.Form.fields.username' => 'email',
+'Auth.Authenticators.Cookie.fields.username' => 'email',
 ```
 
 * Override the login.php template to change the Form->control to "email".


### PR DESCRIPTION
Updated doc `Using the user's email to login` to include required config for 'Remember me'. Related to issue #992