### PR TITLE
Correct casing of users.po in translation docs

### DIFF
--- a/Docs/Documentation/Translations.md
+++ b/Docs/Documentation/Translations.md
@@ -13,6 +13,6 @@ The Plugin is translated into several languages:
 * Turkish (tr_TR) by @sayinserdar
 * Ukrainian (uk) by @yarkm13
 
-**Note:** To overwrite the plugin translations, create a file inside your project 'resources/locales//{$lang}/' folder, with the name 'Users.po' and add the strings with the new translations.
+**Note:** To overwrite the plugin translations, create a file inside your project 'resources/locales//{$lang}/' folder, with the name 'users.po' and add the strings with the new translations.
 
 Remember to clean the translations cache!


### PR DESCRIPTION
The users.po file which is used to overwrite the translations provided by the plugin should be lowercase. Seeing as though translation files are generally lowercase in CakePHP in addition to the fact that as soon as you deploy to a Linux environment the casing will prevent translation.

CakePHP docs:
https://book.cakephp.org/4/en/core-libraries/internationalization-and-localization.html#language-files