### PR TITLE
Add missing parent::initialize() call

### DIFF
--- a/Docs/Documentation/Extending-the-Plugin.md
+++ b/Docs/Documentation/Extending-the-Plugin.md
@@ -178,6 +178,8 @@ You may also need to load some helpers in your AppView:
      */
     public function initialize()
     {
+        parent::initialize();
+
         $this->loadHelper('CakeDC/Users.AuthLink');
         $this->loadHelper('CakeDC/Users.User');
     }


### PR DESCRIPTION
The parent::initialize(); call should be added to the AppView example.