### PR TITLE
Stable CakePHP 5 by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
 	  "prefer-stable": true,
     "require": {
         "php": ">=8.1",
-        "cakephp/cakephp": "5.x-dev",
+        "cakephp/cakephp": "^5.0.0",
         "cakedc/auth": "8.next-cake5-dev",
-        "cakephp/authorization": "3.x-dev",
-        "cakephp/authentication": "3.x-dev"
+        "cakephp/authorization": "^3.0.0",
+        "cakephp/authentication": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "source": "https://github.com/CakeDC/users"
     },
     "minimum-stability": "dev",
-	  "prefer-stable": true,
+    "prefer-stable": true,
     "require": {
         "php": ">=8.1",
         "cakephp/cakephp": "^5.0.0",


### PR DESCRIPTION
Updated composer.json to use stable CakePHP 5 by default