### PR TITLE
Fix named parameter issue in _createSocialUser method for findExistingForSocialLogin #1091 

### DIFF
--- a/src/Model/Behavior/SocialBehavior.php
+++ b/src/Model/Behavior/SocialBehavior.php
@@ -143,7 +143,7 @@ class SocialBehavior extends BaseTokenBehavior
         if ($useEmail && empty($email)) {
             throw new MissingEmailException(__d('cake_d_c/users', 'Email not present'));
         } else {
-            $existingUser = $this->_table->find('existingForSocialLogin', options: ['email' => $email])->first();
+            $existingUser = $this->_table->find('existingForSocialLogin', email: $email )->first();
         }
 
         $user = $this->_populateUser($data, $existingUser, $useEmail, $validateEmail, $tokenExpiration);


### PR DESCRIPTION
This pull request addresses issue #1090, which involves a problem with named parameters in the _createSocialUser method when calling the find method. The issue caused the findExistingForSocialLogin custom finder to not correctly retrieve the 'email' parameter, leading to incorrect query construction.