### PR TITLE
Feature Security Policy Doc: add security policy doc and update READM…

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+We support fixing security issues on the following releases:
+
+| Version | Supported          | Security fixes until
+|---------|--------------------| --------------------
+| 14.2.1  | :white_check_mark: | 12 Months after the release (24 May 2025)
+| 14.1.1  | :white_check_mark: | 12 Months after the release (08 May 2025)
+| 14.0.1  | :white_check_mark: | 12 Months after the release (11 Mar 2025)
+| 13.0.1  | :white_check_mark: | 12 Months after the release (11 Mar 2025)
+| 12.0.0  | :white_check_mark: | 12 Months after the release (06 Nov 2024)
+| 11.3.5  | :white_check_mark: | 12 Months after the release (11 Mar 2025)
+| 11.2.6  | :white_check_mark: | 12 Months after the release (23 Nov 2024)
+| 11.1.1  | :x:                | No longer supported
+| 9.3.1   | :x:                | No longer supported
+| 9.2.1   | :x:                | No longer supported
+| 8.5.2   | :x:                | No longer supported
+
+## Reporting a Vulnerability
+
+If you’ve found a security issue in CakeDC Users plugin, please use the following procedure
+instead of the normal bug reporting system. Instead of using the bug tracker please send an 
+email to security [at] cakedc.com.
+
+For each report, we try to first confirm the vulnerability. Once confirmed,
+the CakeDC team will take the following actions:
+
+* Acknowledge to the reporter that we’ve received the issue, and are
+  working on a fix. We ask that the reporter keep the issue confidential until we announce it.
+* Get a fix/patch prepared.
+* Prepare a post describing the vulnerability, and the possible exploits.
+* Release new versions of all affected versions.
+* Prominently feature the problem in the release announcement

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Contributing
 
 This repository follows the [CakeDC Plugin Standard](https://www.cakedc.com/plugin-standard). If you'd like to contribute new features, enhancements or bug fixes to the plugin, please read our [Contribution Guidelines](https://www.cakedc.com/contribution-guidelines) for detailed instructions.
 
+Security
+------------
+
+If you've found a security issue in CakeDC Users plugin, please use the procedure described in [SECURITY.md](.github/SECURITY.md)
+
 License
 -------
 


### PR DESCRIPTION
Create a security policy doc with the available versions of CakeDC Users plugin and add the security entrance an a link to this docuement on the README file.
Requested on issue #1093.