### PR TITLE
Split rule name for the Rule Checker

### DIFF
--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -197,13 +197,13 @@ class UsersTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->isUnique(['username']), '_isUnique', [
+        $rules->add($rules->isUnique(['username']), '_isUniqueUsername', [
             'errorField' => 'username',
             'message' => __d('cake_d_c/users', 'Username already exists'),
         ]);
 
         if ($this->isValidateEmail) {
-            $rules->add($rules->isUnique(['email']), '_isUnique', [
+            $rules->add($rules->isUnique(['email']), '_isUniqueEmail', [
                 'errorField' => 'email',
                 'message' => __d('cake_d_c/users', 'Email already exists'),
             ]);


### PR DESCRIPTION
When registering a new user after registering a first, we get an error for "A rule with the same name already exists in /web/geoviz2/vendor/cakephp/cakephp/src/Datasource/RulesChecker.php on line 428". This fixes.

Full Stacktrace:
```
2024-10-28 16:04:20 error: [Cake\Core\Exception\CakeException] A rule with the same name already exists in /web/geoviz2/vendor/cakephp/cakephp/src/Datasource/RulesChecker.php on line 428
Stack Trace:
- CORE/src/Datasource/RulesChecker.php:142
- ROOT/vendor/cakedc/users/src/Model/Table/UsersTable.php:206
- CORE/src/Datasource/RulesAwareTrait.php:107
- CORE/src/Datasource/RulesAwareTrait.php:55
- CORE/src/ORM/Table.php:2037
- CORE/src/ORM/Table.php:1973
- CORE/src/ORM/Table.php:1604
- CORE/src/Database/Connection.php:636
- CORE/src/ORM/Table.php:1604
- CORE/src/ORM/Table.php:1972
- ROOT/vendor/cakedc/users/src/Model/Behavior/RegisterBehavior.php:83
- CORE/src/ORM/BehaviorRegistry.php:285
- CORE/src/ORM/Table.php:2827
- ROOT/vendor/cakedc/users/src/Controller/Traits/RegisterTrait.php:108
- CORE/src/Controller/Controller.php:503
- CORE/src/Controller/ControllerFactory.php:166
- CORE/src/Controller/ControllerFactory.php:141
- CORE/src/Http/BaseApplication.php:360
- CORE/src/Http/Runner.php:86
- ROOT/vendor/cakephp/authorization/src/Middleware/RequestAuthorizationMiddleware.php:110
- CORE/src/Http/Runner.php:82
- ROOT/vendor/cakephp/authorization/src/Middleware/AuthorizationMiddleware.php:136
- CORE/src/Http/Runner.php:82
- ROOT/vendor/cakephp/authentication/src/Middleware/AuthenticationMiddleware.php:107
- CORE/src/Http/Runner.php:82
- CORE/src/Http/Middleware/CsrfProtectionMiddleware.php:169
- CORE/src/Http/Runner.php:82
- CORE/src/Http/Middleware/SecurityHeadersMiddleware.php:274
- CORE/src/Http/Runner.php:82
- CORE/src/Http/Middleware/HttpsEnforcerMiddleware.php:95
- CORE/src/Http/Runner.php:82
- CORE/src/Http/Middleware/BodyParserMiddleware.php:162
- CORE/src/Http/Runner.php:82
- CORE/src/Routing/Middleware/RoutingMiddleware.php:118
- CORE/src/Http/Runner.php:82
- CORE/src/Routing/Middleware/AssetMiddleware.php:69
- CORE/src/Http/Runner.php:82
- CORE/src/Error/Middleware/ErrorHandlerMiddleware.php:115
- CORE/src/Http/Runner.php:82
- ROOT/vendor/cakephp/debug_kit/src/Middleware/DebugKitMiddleware.php:60
- CORE/src/Http/Runner.php:82
- CORE/src/Http/Runner.php:60
- CORE/src/Http/Server.php:104
- ROOT/webroot/index.php:37
- [main]:
```