### PR TITLE
Fix CI setup for PHP 8, CakePHP 5.1. Will fix the deprecations in the TestCases in a separate PR.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
 
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Get date part for cache key
       id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
-
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+  
     - name: Cache composer dependencies
       uses: actions/cache@v1
       with:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -136,7 +136,6 @@ class_alias('TestApp\Controller\AppController', 'App\Controller\AppController');
 ]);
 \Cake\Utility\Security::setSalt('yoyz186elmi66ab9pz4imbb3tgy9vnsgsfgwe2r8tyxbbfdygu9e09tlxyg8p7dq');
 
-Plugin::getCollection()->add(new \CakeDC\Users\Plugin());
 session_id('cli');
 
 \Cake\Core\Configure::write('Users.AllowedRedirectHosts', [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,9 +75,9 @@ $cache = [
     'default' => [
         'engine' => 'File',
     ],
-    '_cake_core_' => [
+    '_cake_translations_' => [
         'className' => 'File',
-        'prefix' => 'users_myapp_cake_core_',
+        'prefix' => 'users_myapp_cake_translations_',
         'path' => CACHE . 'persistent/',
         'serialize' => true,
         'duration' => '+10 seconds',


### PR DESCRIPTION
Fix for the PHPUnit testing. Fixes

```log
PHP Deprecated:  Since 5.1.0: Cache config `_cake_core_` is deprecated. Use `_cake_translations_` instead

/home/runner/work/users/users/vendor/cakephp/cakephp/src/I18n/I18n.php, line: 152
You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. Adding `vendor/cakephp/cakephp/src/I18n/I18n.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only. in /home/runner/work/users/users/vendor/cakephp/cakephp/src/Core/functions.php on line 384
Deprecated: Since 5.1.0: Cache config `_cake_core_` is deprecated. Use `_cake_translations_` instead
/home/runner/work/users/users/vendor/cakephp/cakephp/src/I18n/I18n.php, line: 152
You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. Adding `vendor/cakephp/cakephp/src/I18n/I18n.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only. in /home/runner/work/users/users/vendor/cakephp/cakephp/src/Core/functions.php on line 384
PHPUnit 10.5.38 by Sebastian Bergmann and contributors.
```