### PR TITLE
1108 - Fix usage of `superadmin` and `admin` across the plugin

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 14
 :minor: 3
-:patch: 3
+:patch: 4
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 Releases for CakePHP 5
 -------------
+* 14.3.4
+  * Replace usage of 'admin' by UsersTable::ROLE_ADMIN constant across the plugin.
+  * Fix role in UsersAddSuperuserCommand to be 'admin' instead of 'superadmin'.
 * 14.3.3
   * Add compatibility with CakePHP 5.1
 * 14.3.2

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -94,7 +94,7 @@ return [
         ],
         //admin role allowed to all the things
         [
-            'role' => 'admin',
+            'role' => \CakeDC\Users\Model\Table\UsersTable::ROLE_ADMIN,
             'prefix' => '*',
             'extension' => '*',
             'plugin' => '*',

--- a/src/Command/UsersAddSuperuserCommand.php
+++ b/src/Command/UsersAddSuperuserCommand.php
@@ -7,6 +7,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use CakeDC\Users\Command\Logic\CreateUserTrait;
+use CakeDC\Users\Model\Table\UsersTable;
 
 /**
  * UsersAddSuperuser command.
@@ -26,7 +27,7 @@ class UsersAddSuperuserCommand extends Command
     {
         $this->_createUser($args, $io, [
             'username' => 'superadmin',
-            'role' => 'superuser',
+            'role' => UsersTable::ROLE_ADMIN,
             'is_superuser' => true,
         ]);
     }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace CakeDC\Users\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
+use CakeDC\Users\Model\Table\UsersTable;
 use CakeDC\Users\Webauthn\Base64Utility;
 
 /**
@@ -44,7 +45,7 @@ class UsersFixture extends TestFixture
                 'tos_date' => '2015-06-24 17:33:54',
                 'active' => false,
                 'is_superuser' => true,
-                'role' => 'admin',
+                'role' => UsersTable::ROLE_ADMIN,
                 'created' => '2015-06-24 17:33:54',
                 'modified' => '2015-06-24 17:33:54',
                 'additional_data' => [
@@ -85,7 +86,7 @@ class UsersFixture extends TestFixture
                 'tos_date' => '2015-06-24 17:33:54',
                 'active' => true,
                 'is_superuser' => true,
-                'role' => 'admin',
+                'role' => UsersTable::ROLE_ADMIN,
                 'created' => '2015-06-24 17:33:54',
                 'modified' => '2015-06-24 17:33:54',
                 'last_login' => '2015-06-24 17:33:54',
@@ -106,7 +107,7 @@ class UsersFixture extends TestFixture
                 'is_superuser' => true,
                 'tos_date' => '2015-06-24 17:33:54',
                 'active' => false,
-                'role' => 'admin',
+                'role' => UsersTable::ROLE_ADMIN,
                 'created' => '2015-06-24 17:33:54',
                 'modified' => '2015-06-24 17:33:54',
             ],
@@ -146,7 +147,7 @@ class UsersFixture extends TestFixture
                 'tos_date' => '2015-06-24 17:33:54',
                 'active' => true,
                 'is_superuser' => false,
-                'role' => 'user',
+                'role' => UsersTable::ROLE_USER,
                 'created' => '2015-06-24 17:33:54',
                 'modified' => '2015-06-24 17:33:54',
             ],
@@ -166,7 +167,7 @@ class UsersFixture extends TestFixture
                 'tos_date' => '2015-06-24 17:33:54',
                 'active' => true,
                 'is_superuser' => false,
-                'role' => 'user',
+                'role' => UsersTable::ROLE_USER,
                 'created' => '2015-06-24 17:33:54',
                 'modified' => '2015-06-24 17:33:54',
             ],

--- a/tests/TestCase/Command/UsersAddSuperuserCommandTest.php
+++ b/tests/TestCase/Command/UsersAddSuperuserCommandTest.php
@@ -6,6 +6,7 @@ namespace CakeDC\Users\Test\TestCase\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use CakeDC\Users\Model\Table\UsersTable;
 
 /**
  * CakeDC\Users\Command\UsersAddSuperuserCommand Test Case
@@ -66,7 +67,7 @@ class UsersAddSuperuserCommandTest extends TestCase
         $this->assertOutputRegExp('/^Superuser added:/');
         $this->assertOutputRegExp('/Username: superadmin/');
         $this->assertOutputRegExp('/Email: superadmin@example.com/');
-        $this->assertOutputRegExp('/Role: superuser/');
+        $this->assertOutputRegExp('/Role: ' . UsersTable::ROLE_ADMIN . '/');
         $this->assertOutputRegExp('/Password: [a-z0-9]{32}$/');
     }
 }

--- a/tests/TestCase/Command/UsersChangeRoleCommandTest.php
+++ b/tests/TestCase/Command/UsersChangeRoleCommandTest.php
@@ -6,6 +6,7 @@ namespace CakeDC\Users\Test\TestCase\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use CakeDC\Users\Model\Table\UsersTable;
 
 /**
  * CakeDC\Users\Command\UsersChangeRoleCommand Test Case
@@ -37,8 +38,8 @@ class UsersChangeRoleCommandTest extends TestCase
         $userId006 = '00000000-0000-0000-0000-000000000006';
         $roleBefore = 'Lorem ipsum dolor sit amet';
         $userId001 = '00000000-0000-0000-0000-000000000001';
-        $role001 = 'admin';
-        $role006 = 'user';
+        $role001 = UsersTable::ROLE_ADMIN;
+        $role006 = UsersTable::ROLE_USER;
         $this->assertTrue($UsersTable->exists(['id' => $userIdTarget, 'role' => $roleBefore]));
         $this->assertTrue($UsersTable->exists(['id' => $userId001, 'role' => $role001]));
         $this->assertTrue($UsersTable->exists(['id' => $userId006, 'role' => $role006]));
@@ -71,8 +72,8 @@ class UsersChangeRoleCommandTest extends TestCase
         $userId006 = '00000000-0000-0000-0000-000000000006';
         $roleBefore = 'Lorem ipsum dolor sit amet';
         $userId001 = '00000000-0000-0000-0000-000000000001';
-        $role001 = 'admin';
-        $role006 = 'user';
+        $role001 = UsersTable::ROLE_ADMIN;
+        $role006 = UsersTable::ROLE_USER;
         $this->assertTrue($UsersTable->exists(['id' => $userIdTarget, 'role' => $roleBefore]));
         $this->assertTrue($UsersTable->exists(['id' => $userId001, 'role' => $role001]));
         $this->assertTrue($UsersTable->exists(['id' => $userId006, 'role' => $role006]));


### PR DESCRIPTION
Fixes #1108 