### PR TITLE
Update PasswordManagementTrait.php

### DIFF
--- a/src/Controller/Traits/PasswordManagementTrait.php
+++ b/src/Controller/Traits/PasswordManagementTrait.php
@@ -186,6 +186,7 @@ trait PasswordManagementTrait
                 'If the account is valid, the system will send an instructional email to the address on record.',
             );
             $this->Flash->success($msg);
+            return $this->redirect(['action' => 'login']);
         } catch (Exception $exception) {
             $msg = __d('cake_d_c/users', 'There was an error please contact Administrator');
             $this->Flash->error($msg);


### PR DESCRIPTION
Fix password reset flow: redirect to login action if no user is found.

An issue in the password reset flow where the application would not properly handle cases when no user is found.

By redirecting to the login screen when no user is found, we enhance security and user experience. Previously, the application would remain on the reset password form, which could inadvertently reveal whether a user exists or not based on the action taken.