### PR TITLE
fix token mail not working with custom Controller config + fix tests failing with latest cake

### DIFF
--- a/src/Mailer/UsersMailer.php
+++ b/src/Mailer/UsersMailer.php
@@ -15,7 +15,6 @@ namespace CakeDC\Users\Mailer;
 use Cake\Datasource\EntityInterface;
 use Cake\Mailer\Mailer;
 use Cake\Mailer\Message;
-use Cake\Routing\Router;
 use CakeDC\Users\Utility\UsersUrl;
 
 /**

--- a/src/Mailer/UsersMailer.php
+++ b/src/Mailer/UsersMailer.php
@@ -139,13 +139,12 @@ class UsersMailer extends Mailer
     public function sendToken(EntityInterface $user, string $token): void
     {
         $this->viewBuilder()->setTemplate('CakeDC/Users.onetimeToken');
-        $loginLink = Router::url([
-            'controller' => 'Users',
-            'action' => 'singleTokenLogin',
+        $loginLink = UsersUrl::actionUrl('singleTokenLogin', [
             '?' => [
                 'token' => $token,
             ],
-        ], true);
+            '_full' => true,
+        ]);
         $this->setTo($user->email);
         $this->setSubject(__d('cake_d_c/users', 'Your One-Time Login Token'));
         $this->setEmailFormat('html');

--- a/src/Model/Behavior/RegisterBehavior.php
+++ b/src/Model/Behavior/RegisterBehavior.php
@@ -163,7 +163,7 @@ class RegisterBehavior extends BaseTokenBehavior
     {
         $this->validateEmail = (bool)$validateEmail;
         $validator
-            ->add('email', 'valid', ['rule' => 'email'])
+            ->add('email', 'valid_email', ['rule' => 'email'])
             ->notBlank('email', __d('cake_d_c/users', 'This field is required'), function ($context) {
                 return $this->validateEmail;
             });
@@ -197,8 +197,7 @@ class RegisterBehavior extends BaseTokenBehavior
         $validateEmail = $options['validate_email'] ?? null;
         $useTos = $options['use_tos'] ?? null;
 
-        $validator = $this->_table->validationDefault(new Validator());
-        $validator = $this->_table->validationRegister($validator);
+        $validator = $this->_table->validationRegister(new Validator());
         if ($useTos) {
             $validator = $this->_tosValidator($validator);
         }

--- a/src/Model/Table/SocialAccountsTable.php
+++ b/src/Model/Table/SocialAccountsTable.php
@@ -59,7 +59,7 @@ class SocialAccountsTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->add('id', 'valid', ['rule' => 'uuid'])
+            ->add('id', 'valid_id', ['rule' => 'uuid'])
             ->allowEmptyString('id', null, 'create');
 
         $validator
@@ -91,11 +91,11 @@ class SocialAccountsTable extends Table
             ->allowEmptyString('token_secret');
 
         $validator
-            ->add('token_expires', 'valid', ['rule' => 'datetime'])
+            ->add('token_expires', 'valid_social_token_expires', ['rule' => 'datetime'])
             ->allowEmptyString('token_expires');
 
         $validator
-            ->add('active', 'valid', ['rule' => 'boolean'])
+            ->add('active', 'valid_active', ['rule' => 'boolean'])
             ->requirePresence('active', 'create')
             ->notBlank('active');
 

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -160,18 +160,18 @@ class UsersTable extends Table
             ->allowEmptyString('token');
 
         $validator
-            ->add('token_expires', 'valid', ['rule' => 'datetime'])
+            ->add('token_expires', 'valid_user_token_expires', ['rule' => 'datetime'])
             ->allowEmptyDateTime('token_expires');
 
         $validator
             ->allowEmptyString('api_token');
 
         $validator
-            ->add('activation_date', 'valid', ['rule' => 'datetime'])
+            ->add('activation_date', 'valid_activation_date', ['rule' => 'datetime'])
             ->allowEmptyDateTime('activation_date');
 
         $validator
-            ->add('tos_date', 'valid', ['rule' => 'datetime'])
+            ->add('tos_date', 'valid_tos_date', ['rule' => 'datetime'])
             ->allowEmptyDateTime('tos_date');
 
         return $validator;


### PR DESCRIPTION
If someone configures their instance to use a custom controller and table class like so in their `config/users.php`
```
'table' => 'AlfredStaffMembers.StaffMembers',
'controller' => 'AlfredStaffMembers.StaffMembers',
```

the mail for a one time login URL doesn't work since it was hardcoded to use the UsersController, therefore causing a Router exception.

Basically (as far as I can see) there should never be `'controller' => 'Users',` anywhere in the `src` directory of this plugin, since all the Urls should be generated via the `UsersUrl` Utility to make sure it respects the users config.

Also latest cake requires rule names to be unique, therefore I just adjusted the already existing ones to make the CI green again.