### PR TITLE
Update EmailDelivery

### DIFF
--- a/src/Model/Behavior/OneTimeDelivery/EmailDelivery.php
+++ b/src/Model/Behavior/OneTimeDelivery/EmailDelivery.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Users\Model\Behavior\OneTimeDelivery;
 
+use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Mailer\MailerAwareTrait;
 
@@ -37,6 +38,8 @@ class EmailDelivery implements DeliveryInterface
      */
     public function send(EntityInterface $user, string $token): void
     {
-        $this->getMailer('CakeDC/Users.Users')->send('sendToken', [$user, $token]);
+        $this
+            ->getMailer(Configure::read('Users.Email.mailerClass') ?: 'CakeDC/Users.Users')
+            ->send('sendToken', [$user, $token]);
     }
 }


### PR DESCRIPTION
Allow the mailer to be configurable in the OneTimeLogin flow, like in all other flows, such as user validation and password reset.