### PR TITLE
 SocialBehavior: Set provider in extractAccountData before marshalling

### DIFF
--- a/src/Model/Behavior/SocialBehavior.php
+++ b/src/Model/Behavior/SocialBehavior.php
@@ -304,6 +304,7 @@ class SocialBehavior extends BaseTokenBehavior
         $accountData['reference'] = $data['id'] ?? null;
         $accountData['avatar'] = $data['avatar'] ?? null;
         $accountData['link'] = $data['link'] ?? null;
+        $accountData['provider'] = $data['provider'] ?? null;
 
         if ($accountData['avatar'] ?? null) {
             $accountData['avatar'] = str_replace('normal', 'square', $accountData['avatar']);


### PR DESCRIPTION
Ensure the provider field is included in extractAccountData so associated SocialAccounts validation passes during newEntity marshalling.
Fixes missing 'provider' validation error observed with Keycloak (and potentially others) when creating users.
No impact on existing accounts; provider remains enforced later as well.
Aligns data flow with validator requirements to avoid premature validation failures.
