### PR TITLE
Only set column type for "additional_data" if column exists

### DIFF
--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -84,7 +84,9 @@ class UsersTable extends Table
     public function getSchema(): TableSchemaInterface
     {
         $schema = parent::getSchema();
-        $schema->setColumnType('additional_data', 'json');
+        if ($schema->hasColumn('additional_data')) {
+            $schema->setColumnType('additional_data', 'json');
+        }
 
         return $schema;
     }


### PR DESCRIPTION
We didnt add this field (yet) and ran into a problem while upgrading to CakePHP 5.x and with it to this version of the users plugin.

> Column `additional_data` of table `users`: The column type `json` can only be set if the column already exists; can be checked using `hasColumn()`.

So we propose to only set the column type when the column actually exists.