### PR TITLE
adjust migrations to use new BaseMigration class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "cakephp/authentication": "^3.0"
     },
     "require-dev": {
+        "cakephp/migrations": "^4.5.1",
         "phpunit/phpunit": "^10.0",
         "league/oauth2-facebook": "@stable",
         "league/oauth2-instagram": "@stable",

--- a/config/Migrations/20150513201111_initial.php
+++ b/config/Migrations/20150513201111_initial.php
@@ -9,9 +9,9 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class Initial extends AbstractMigration
+class Initial extends BaseMigration
 {
     public function change()
     {

--- a/config/Migrations/20161031101316_AddSecretToUsers.php
+++ b/config/Migrations/20161031101316_AddSecretToUsers.php
@@ -9,9 +9,9 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddSecretToUsers extends AbstractMigration
+class AddSecretToUsers extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20190208174112_AddAdditionalDataToUsers.php
+++ b/config/Migrations/20190208174112_AddAdditionalDataToUsers.php
@@ -9,9 +9,9 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddAdditionalDataToUsers extends AbstractMigration
+class AddAdditionalDataToUsers extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20210929202041_AddLastLoginToUsers.php
+++ b/config/Migrations/20210929202041_AddLastLoginToUsers.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddLastLoginToUsers extends AbstractMigration
+class AddLastLoginToUsers extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20240328135459_CreateFailedPasswordAttempts.php
+++ b/config/Migrations/20240328135459_CreateFailedPasswordAttempts.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CreateFailedPasswordAttempts extends AbstractMigration
+class CreateFailedPasswordAttempts extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20240328215332_AddLockoutTimeToUsers.php
+++ b/config/Migrations/20240328215332_AddLockoutTimeToUsers.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddLockoutTimeToUsers extends AbstractMigration
+class AddLockoutTimeToUsers extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20240801112143_ChangeAvatarColumnTypeInSocialAccounts.php
+++ b/config/Migrations/20240801112143_ChangeAvatarColumnTypeInSocialAccounts.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ChangeAvatarColumnTypeInSocialAccounts extends AbstractMigration
+class ChangeAvatarColumnTypeInSocialAccounts extends BaseMigration
 {
     /**
      * Change Method.

--- a/config/Migrations/20250124082232_AddLoginTokenToUsers.php
+++ b/config/Migrations/20250124082232_AddLoginTokenToUsers.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddLoginTokenToUsers extends AbstractMigration
+class AddLoginTokenToUsers extends BaseMigration
 {
     /**
      * Change Method.


### PR DESCRIPTION
This makes the plugin work with the new migrations v5 version as it has removed the old phinx package.