### PR TITLE
fix deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,14 @@ parameters:
 			path: src/Controller/Component/LoginComponent.php
 
 		-
-			message: "#^Call to an undefined method Cake\\\\Controller\\\\Controller\\:\\:getUsersTable\\(\\)\\.$#"
+			message: '#^Call to an undefined method Cake\\Controller\\Controller\:\:getUsersTable\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Controller/Component/LoginComponent.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Authentication\\Authenticator\\AuthenticatorInterface and ''getIdentifier'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Controller/Component/LoginComponent.php
 
@@ -54,7 +61,8 @@ parameters:
 			path: src/Model/Behavior/LinkSocialBehavior.php
 
 		-
-			message: "#^Access to an undefined property Cake\\\\Datasource\\\\EntityInterface\\:\\:\\$activation_date\\.$#"
+			message: '#^Access to an undefined property Cake\\Datasource\\EntityInterface\:\:\$activation_date\.$#'
+			identifier: property.notFound
 			count: 1
 			path: src/Model/Behavior/RegisterBehavior.php
 

--- a/src/Controller/Component/LoginComponent.php
+++ b/src/Controller/Component/LoginComponent.php
@@ -205,17 +205,20 @@ class LoginComponent extends Component
 
         // new way to define identifiers, inside the authenticators
         $authenticatorNames = (array)Configure::read('Auth.PasswordRehash.authenticators');
+        if ($authenticatorNames === []) {
+            return;
+        }
+
+        $authenticationProvider = $service->getAuthenticationProvider();
+        if (!$authenticationProvider || !method_exists($authenticationProvider, 'getIdentifier')) {
+            return;
+        }
+
+        /** @var \Authentication\Identifier\IdentifierCollection $identifierCollection */
+        $identifierCollection = $authenticationProvider->getIdentifier();
         foreach ($authenticatorNames as $authenticatorName => $identifierName) {
-            if (!$service->authenticators()->has($authenticatorName)) {
-                Log::warning("Error saving user id $user->id password after rehashing: authenticator $authenticatorName not found. Check your Auth.PasswordRehash.authenticators configuration.");
-                continue;
-            }
-            /**
-             * @var \Authentication\Identifier\IdentifierCollection $identifierCollection
-             */
-            $identifierCollection = $service->authenticators()->get($authenticatorName)->getIdentifier();
             if (!$identifierCollection->has($identifierName)) {
-                Log::warning("Error saving user id $user->id password after rehashing: identifier $identifierName not found. Check your Auth.PasswordRehash.authenticators configuration.");
+                Log::warning("Error saving user id $user->id password after rehashing: identifier $identifierName not found for authenticator $authenticatorName. Check your Auth.PasswordRehash.authenticators configuration.");
                 continue;
             }
 

--- a/src/Controller/Traits/LinkSocialTrait.php
+++ b/src/Controller/Traits/LinkSocialTrait.php
@@ -72,7 +72,9 @@ trait LinkSocialTrait
             $userId = $identity['id'] ?? null;
             $user = $this->getUsersTable()->get($userId);
 
-            $this->getUsersTable()->linkSocialAccount($user, $data);
+            /** @var \CakeDC\Users\Model\Behavior\LinkSocialBehavior $linkSocial */
+            $linkSocial = $this->getUsersTable()->getBehavior('LinkSocial');
+            $linkSocial->linkSocialAccount($user, $data);
 
             if ($user->getErrors()) {
                 $this->Flash->error($message);

--- a/src/Model/Behavior/OneTimeLoginLinkBehavior.php
+++ b/src/Model/Behavior/OneTimeLoginLinkBehavior.php
@@ -25,7 +25,7 @@ class OneTimeLoginLinkBehavior extends Behavior
     public function sendLoginLink(string $name): void
     {
         $table = $this->table();
-        $user = $table->find('byUsernameOrEmail', ['username' => $name])->first();
+        $user = $table->find('byUsernameOrEmail', username: $name)->first();
         if ($user === null) {
             throw new RecordNotFoundException(__('Username not found.'));
         }
@@ -65,7 +65,7 @@ class OneTimeLoginLinkBehavior extends Behavior
     {
         $lifeTime = Configure::read('Auth.OneTimeLogin.tokenLifeTime', 600);
         $user = $this->table()
-            ->find('byOneTimeToken', ['token' => $token])
+            ->find('byOneTimeToken', token: $token)
             ->first();
 
         if ($user && ($user->login_token_date >= DateTime::now()->subSeconds($lifeTime))) {
@@ -89,7 +89,7 @@ class OneTimeLoginLinkBehavior extends Behavior
      */
     public function requestTokenSend(string $username): void
     {
-        $user = $this->table()->find('byUsernameOrEmail', ['username' => $username])->first();
+        $user = $this->table()->find('byUsernameOrEmail', username: $username)->first();
         if ($user) {
             $this->table()->updateAll([
                 'token_send_requested' => true,
@@ -103,12 +103,11 @@ class OneTimeLoginLinkBehavior extends Behavior
      * Find by username or email.
      *
      * @param \Cake\ORM\Query $query The query builder.
-     * @param array $options Options.
+     * @param string|null $username Username or email.
      * @return \Cake\ORM\Query
      */
-    public function findByUsernameOrEmail(Query $query, array $options = []): Query
+    public function findByUsernameOrEmail(Query $query, ?string $username = null): Query
     {
-        $username = $options['username'] ?? null;
         if (empty($username)) {
             throw new OutOfBoundsException('Missing username');
         }
@@ -125,12 +124,11 @@ class OneTimeLoginLinkBehavior extends Behavior
      * Find by token
      *
      * @param \Cake\ORM\Query $query
-     * @param array $options
+     * @param string|null $token
      * @return \Cake\ORM\Query
      */
-    public function findByOneTimeToken(Query $query, array $options = []): Query
+    public function findByOneTimeToken(Query $query, ?string $token = null): Query
     {
-        $token = $options['token'] ?? null;
         if (empty($token)) {
             throw new OutOfBoundsException('Missing token');
         }

--- a/tests/TestCase/Controller/Traits/BaseTrait.php
+++ b/tests/TestCase/Controller/Traits/BaseTrait.php
@@ -16,7 +16,6 @@ namespace CakeDC\Users\Test\TestCase\Controller\Traits;
 use Authentication\Authenticator\Result;
 use Authentication\Controller\Component\AuthenticationComponent;
 use Authentication\Identifier\IdentifierCollection;
-use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Identity;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
@@ -239,14 +238,7 @@ class BaseTrait extends TestCase
     protected function _mockAuthentication($user = null, $failures = [], $identifiers = null)
     {
         if ($identifiers === null) {
-            $passwordIdentifier = $this->getMockBuilder(PasswordIdentifier::class)
-                ->onlyMethods(['needsPasswordRehash'])
-                ->getMock();
-            $passwordIdentifier->expects($this->any())
-                ->method('needsPasswordRehash')
-                ->willReturn(false);
             $identifiers = new IdentifierCollection([]);
-            $identifiers->set('Password', $passwordIdentifier);
         }
 
         $config = [

--- a/tests/TestCase/Controller/Traits/LinkSocialTraitTest.php
+++ b/tests/TestCase/Controller/Traits/LinkSocialTraitTest.php
@@ -58,7 +58,7 @@ class LinkSocialTraitTest extends BaseTrait
         parent::setUp();
         $request = new ServerRequest();
         $this->Trait = $this->getMockBuilder('CakeDC\Users\Controller\UsersController')
-            ->onlyMethods(['dispatchEvent', 'redirect', 'set'])
+            ->onlyMethods(['dispatchEvent', 'redirect', 'set', 'getUsersTable'])
             ->setConstructorArgs([new ServerRequest()])
             ->getMock();
 
@@ -142,11 +142,11 @@ class LinkSocialTraitTest extends BaseTrait
 
         $this->Provider->expects($this->any())
             ->method('getState')
-            ->will($this->returnValue('_NEW_STATE_'));
+            ->willReturn('_NEW_STATE_');
 
         $this->Provider->expects($this->any())
             ->method('getAuthorizationUrl')
-            ->will($this->returnValue('http://facebook.com/redirect/url'));
+            ->willReturn('http://facebook.com/redirect/url');
 
         $this->Trait->Flash->expects($this->never())
             ->method('error');
@@ -157,7 +157,7 @@ class LinkSocialTraitTest extends BaseTrait
         $this->Trait->expects($this->once())
             ->method('redirect')
             ->with($this->equalTo('http://facebook.com/redirect/url'))
-            ->will($this->returnValue(new Response()));
+            ->willReturn(new Response());
 
         $this->Trait->linkSocial('facebook');
     }
@@ -226,14 +226,14 @@ class LinkSocialTraitTest extends BaseTrait
                 $this->equalTo('authorization_code'),
                 $this->equalTo(['code' => 'ZPO9972j3092304230']),
             )
-            ->will($this->returnValue($Token));
+            ->willReturn($Token);
 
         $this->Provider->expects($this->any())
             ->method('getResourceOwner')
             ->with(
                 $this->equalTo($Token),
             )
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $this->Trait = $this->getMockBuilder('CakeDC\Users\Controller\UsersController')
             ->onlyMethods(['dispatchEvent', 'redirect', 'set', 'getUsersTable', 'log'])
@@ -258,7 +258,7 @@ class LinkSocialTraitTest extends BaseTrait
 
         $this->Trait->expects($this->any())
             ->method('getUsersTable')
-            ->will($this->returnValue($Table));
+            ->willReturn($Table);
 
         $this->_mockAuthLoggedIn();
         $this->_mockDispatchEvent(new Event('event'));
@@ -311,19 +311,26 @@ class LinkSocialTraitTest extends BaseTrait
         ]);
         $Table = $this->getMockBuilder(\CakeDC\Users\Model\Table\UsersTable::class)
             ->setConstructorArgs([['alias' => 'Users', 'connection' => \Cake\Datasource\ConnectionManager::get('test')]])
-            ->onlyMethods(['newEntity', 'get'])
-            ->addMethods(['linkSocialAccount'])
+            ->onlyMethods(['newEntity', 'get', 'getBehavior'])
+            ->getMock();
+        $behavior = $this->getMockBuilder(\CakeDC\Users\Model\Behavior\LinkSocialBehavior::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['linkSocialAccount'])
             ->getMock();
 
         $Table->setAlias('Users');
 
         $Table->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $Table->expects($this->once())
+            ->method('getBehavior')
+            ->with('LinkSocial')
+            ->willReturn($behavior);
+        $behavior->expects($this->once())
             ->method('linkSocialAccount')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $Token = new \League\OAuth2\Client\Token\AccessToken([
             'access_token' => 'test-token',
@@ -377,14 +384,14 @@ class LinkSocialTraitTest extends BaseTrait
                 $this->equalTo('authorization_code'),
                 $this->equalTo(['code' => 'ZPO9972j3092304230']),
             )
-            ->will($this->returnValue($Token));
+            ->willReturn($Token);
 
         $this->Provider->expects($this->any())
             ->method('getResourceOwner')
             ->with(
                 $this->equalTo($Token),
             )
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $this->Trait = $this->getMockBuilder('CakeDC\Users\Controller\UsersController')
             ->onlyMethods(['dispatchEvent', 'redirect', 'set', 'getUsersTable', 'log'])
@@ -393,7 +400,7 @@ class LinkSocialTraitTest extends BaseTrait
 
         $this->Trait->expects($this->any())
             ->method('getUsersTable')
-            ->will($this->returnValue($Table));
+            ->willReturn($Table);
 
         $this->Trait->setRequest(ServerRequestFactory::fromGlobals());
         $this->Trait->getRequest()->getSession()->write('oauth2state', '__TEST_STATE__');

--- a/tests/TestCase/Controller/Traits/ReCaptchaTraitTest.php
+++ b/tests/TestCase/Controller/Traits/ReCaptchaTraitTest.php
@@ -110,7 +110,6 @@ class ReCaptchaTraitTest extends TestCase
         Configure::write('Users.reCaptcha.secret', 'secret');
         $trait = $this->getMockBuilder('CakeDC\Users\Controller\Traits\ReCaptchaTrait')->getMockForTrait();
         $method = new ReflectionMethod(get_class($trait), '_getReCaptchaInstance');
-        $method->setAccessible(true);
         $method->invokeArgs($trait, []);
         $this->assertNotEmpty($method->invoke($trait));
     }
@@ -119,7 +118,6 @@ class ReCaptchaTraitTest extends TestCase
     {
         $trait = $this->getMockBuilder('CakeDC\Users\Controller\Traits\ReCaptchaTrait')->getMockForTrait();
         $method = new ReflectionMethod(get_class($trait), '_getReCaptchaInstance');
-        $method->setAccessible(true);
         $method->invokeArgs($trait, []);
         $this->assertNull($method->invoke($trait));
     }

--- a/tests/TestCase/Mailer/UsersMailerTest.php
+++ b/tests/TestCase/Mailer/UsersMailerTest.php
@@ -176,7 +176,6 @@ class UsersMailerTest extends TestCase
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($object, $parameters);
     }

--- a/tests/TestCase/Model/Behavior/LinkSocialBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LinkSocialBehaviorTest.php
@@ -304,7 +304,7 @@ class LinkSocialBehaviorTest extends TestCase
 
         return [
                 'provider' => [
-                    'data' => [
+                    [
                         'id' => 'reference-2-1',
                         'username' => null,
                         'full_name' => 'Full name',
@@ -332,8 +332,8 @@ class LinkSocialBehaviorTest extends TestCase
                         'link' => 'facebook-link-15579',
                         'provider' => 'Facebook',
                     ],
-                    'user' => '00000000-0000-0000-0000-000000000001',
-                    'result' => [
+                    '00000000-0000-0000-0000-000000000001',
+                    [
                         'id' => '00000000-0000-0000-0000-000000000003',
                         'provider' => 'Facebook',
                         'username' => null,

--- a/tests/TestCase/Model/Behavior/OneTimeLoginLinkBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/OneTimeLoginLinkBehaviorTest.php
@@ -193,7 +193,7 @@ class OneTimeLoginLinkBehaviorTest extends TestCase
     public function testFindByUsernameOrEmailMissingUsername(): void
     {
         $this->expectException(OutOfBoundsException::class);
-        $this->table->find('byUsernameOrEmail', [])->first();
+        $this->table->find('byUsernameOrEmail')->first();
     }
 
     /**
@@ -204,6 +204,6 @@ class OneTimeLoginLinkBehaviorTest extends TestCase
     public function testFindByOneTimeTokenMissingToken(): void
     {
         $this->expectException(OutOfBoundsException::class);
-        $this->table->find('byOneTimeToken', [])->first();
+        $this->table->find('byOneTimeToken')->first();
     }
 }

--- a/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordBehaviorTest.php
@@ -292,7 +292,6 @@ class PasswordBehaviorTest extends TestCase
         $realBehavior = $this->table->getBehavior('Password');
 
         $method = new ReflectionMethod(get_class($realBehavior), '_getUser');
-        $method->setAccessible(true);
 
         return $method->invoke($realBehavior, $reference);
     }


### PR DESCRIPTION
key fixes:

- Replaced deprecated behavior-table proxy calls with explicit behavior access
- Replaced deprecated finder options-array usage with named arguments and updated finder signatures.
- Removed deprecated ReflectionMethod::setAccessible() calls in tests.
- Adjusted login rehash flow to avoid deprecated identifier-loading path.
- Fixed a PHPUnit deprecation caused by named data-provider argument keys.