### PR TITLE
Use cryptographically secure random bytes in RandomStringTrait

### DIFF
--- a/src/Traits/RandomStringTrait.php
+++ b/src/Traits/RandomStringTrait.php
@@ -26,8 +26,6 @@ trait RandomStringTrait
         if (!is_numeric($length) || $length <= 0) {
             $length = 10;
         }
-        $string = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-        return substr(str_shuffle($string), 0, $length);
+        return substr(bin2hex(random_bytes((int)ceil($length / 2))), 0, $length);
     }
 }

--- a/src/Traits/RandomStringTrait.php
+++ b/src/Traits/RandomStringTrait.php
@@ -26,6 +26,14 @@ trait RandomStringTrait
         if (!is_numeric($length) || $length <= 0) {
             $length = 10;
         }
-        return substr(bin2hex(random_bytes((int)ceil($length / 2))), 0, $length);
+        $length = (int)$length;
+        $alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $alphabetLength = strlen($alphabet);
+        $result = '';
+        for ($i = 0; $i < $length; $i++) {
+            $result .= $alphabet[random_int(0, $alphabetLength - 1)];
+        }
+
+        return $result;
     }
 }

--- a/tests/TestCase/Traits/RandomStringTraitTest.php
+++ b/tests/TestCase/Traits/RandomStringTraitTest.php
@@ -46,8 +46,16 @@ class RandomStringTraitTest extends TestCase
         $first = $this->Trait->randomString(32);
         $second = $this->Trait->randomString(32);
 
+        $this->assertSame(32, strlen($first));
+        $this->assertSame(32, strlen($second));
         $this->assertNotSame($first, $second);
-        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $first);
-        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $second);
+        $this->assertMatchesRegularExpression('/^[0-9a-zA-Z]+$/', $first);
+        $this->assertMatchesRegularExpression('/^[0-9a-zA-Z]+$/', $second);
+    }
+
+    public function testRandomStringOddLength()
+    {
+        $this->assertSame(31, strlen($this->Trait->randomString(31)));
+        $this->assertSame(1, strlen($this->Trait->randomString(1)));
     }
 }

--- a/tests/TestCase/Traits/RandomStringTraitTest.php
+++ b/tests/TestCase/Traits/RandomStringTraitTest.php
@@ -33,18 +33,21 @@ class RandomStringTraitTest extends TestCase
         parent::tearDown();
     }
 
-    public function testRandomString()
+    public function testRandomStringLength()
     {
-        $result = $this->Trait->randomString();
-        $this->assertEquals(10, strlen($result));
+        $this->assertSame(10, strlen($this->Trait->randomString()));
+        $this->assertSame(30, strlen($this->Trait->randomString(30)));
+        $this->assertSame(10, strlen($this->Trait->randomString('-300')));
+        $this->assertSame(10, strlen($this->Trait->randomString('text')));
+    }
 
-        $result = $this->Trait->randomString(30);
-        $this->assertEquals(30, strlen($result));
+    public function testRandomStringUsesSecureRandomness()
+    {
+        $first = $this->Trait->randomString(32);
+        $second = $this->Trait->randomString(32);
 
-        $result = $this->Trait->randomString('-300');
-        $this->assertEquals(10, strlen($result));
-
-        $result = $this->Trait->randomString('text');
-        $this->assertEquals(10, strlen($result));
+        $this->assertNotSame($first, $second);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $first);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $second);
     }
 }


### PR DESCRIPTION
str_shuffle() relies on mt_rand which is not cryptographically secure. Replace with random_bytes() so placeholder passwords for social-login users cannot be predicted.

Output changes from alphanumeric [a-zA-Z0-9] to hex [0-9a-f].