### PR TITLE
Clear token after email activation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,19 +61,7 @@ parameters:
 			path: src/Model/Behavior/LinkSocialBehavior.php
 
 		-
-			message: '#^Access to an undefined property Cake\\Datasource\\EntityInterface\:\:\$activation_date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Model/Behavior/RegisterBehavior.php
-
-		-
 			message: '#^Access to an undefined property Cake\\Datasource\\EntityInterface\:\:\$active\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Model/Behavior/RegisterBehavior.php
-
-		-
-			message: '#^Access to an undefined property Cake\\Datasource\\EntityInterface\:\:\$token_expires\.$#'
 			identifier: property.notFound
 			count: 1
 			path: src/Model/Behavior/RegisterBehavior.php

--- a/src/Model/Behavior/RegisterBehavior.php
+++ b/src/Model/Behavior/RegisterBehavior.php
@@ -128,8 +128,9 @@ class RegisterBehavior extends BaseTokenBehavior
         if ($user->active) {
             throw new UserAlreadyActiveException(__d('cake_d_c/users', 'User account already validated'));
         }
-        $user->activation_date = new \DateTime();
+        $user->token = null;
         $user->token_expires = null;
+        $user->activation_date = new \DateTime();
         $user->active = true;
 
         return $this->_table->save($user);

--- a/src/Model/Behavior/RegisterBehavior.php
+++ b/src/Model/Behavior/RegisterBehavior.php
@@ -128,10 +128,10 @@ class RegisterBehavior extends BaseTokenBehavior
         if ($user->active) {
             throw new UserAlreadyActiveException(__d('cake_d_c/users', 'User account already validated'));
         }
-        $user->token = null;
-        $user->token_expires = null;
-        $user->activation_date = new \DateTime();
-        $user->active = true;
+        $user->set('token', null);
+        $user->set('token_expires', null);
+        $user->set('activation_date', new \DateTime());
+        $user->set('active', true);
 
         return $this->_table->save($user);
     }

--- a/tests/TestCase/Controller/Traits/Integration/RegisterTraitIntegrationTest.php
+++ b/tests/TestCase/Controller/Traits/Integration/RegisterTraitIntegrationTest.php
@@ -123,7 +123,7 @@ class RegisterTraitIntegrationTest extends TestCase
         //If access again get error
         $this->get($url);
         $this->assertRedirect('/login');
-        $this->assertFlashMessage('Token already expired');
+        $this->assertFlashMessage('Invalid token or user account already validated');
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RegisterBehaviorTest.php
@@ -304,6 +304,7 @@ class RegisterBehaviorTest extends TestCase
 
         $result = $this->Behavior->activateUser($user);
         $this->assertSame($result, $user);
+        $this->assertNull($user->token);
         $this->assertNull($user->token_expires);
         $this->assertTrue($user->active);
         $this->assertInstanceOf(\DateTime::class, $user->activation_date);


### PR DESCRIPTION
activateUser() was setting token_expires to null but leaving the token value in the database. Old activation links remained usable if token_expires was ever reset. Now both fields are cleared on activation, consistent with how PasswordBehavior handles password reset tokens.