### PR TITLE
fix: correct config keys and hardcoded threshold in OneTimeLoginLinkB…

### DIFF
--- a/src/Model/Behavior/OneTimeLoginLinkBehavior.php
+++ b/src/Model/Behavior/OneTimeLoginLinkBehavior.php
@@ -32,7 +32,8 @@ class OneTimeLoginLinkBehavior extends Behavior
 
         $loginTokenDate = $user->login_token_date ?? null;
 
-        if ($loginTokenDate && $loginTokenDate > DateTime::now()->subSeconds(10)) {
+        $threshold = Configure::read('OneTimeLogin.thresholdTimeout', 60);
+        if ($loginTokenDate && $loginTokenDate > DateTime::now()->subSeconds($threshold)) {
             $this->requestTokenSend($name);
         } else {
             $token = bin2hex(random_bytes(32 / 2));
@@ -63,7 +64,7 @@ class OneTimeLoginLinkBehavior extends Behavior
      */
     public function loginWithToken(string $token): ?EntityInterface
     {
-        $lifeTime = Configure::read('Auth.OneTimeLogin.tokenLifeTime', 600);
+        $lifeTime = Configure::read('OneTimeLogin.tokenLifeTime', 600);
         $user = $this->table()
             ->find('byOneTimeToken', token: $token)
             ->first();

--- a/tests/TestCase/Model/Behavior/OneTimeLoginLinkBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/OneTimeLoginLinkBehaviorTest.php
@@ -157,7 +157,7 @@ class OneTimeLoginLinkBehaviorTest extends TestCase
             ['id' => $user->id],
         );
 
-        Configure::write('Auth.OneTimeLogin.tokenLifeTime', 600);
+        Configure::write('OneTimeLogin.tokenLifeTime', 600);
         $loggedUser = $this->Behavior->loginWithToken($token);
         $this->assertNull($loggedUser);
     }


### PR DESCRIPTION
…ehavior

- Read threshold from OneTimeLogin.thresholdTimeout config (was hardcoded to 10s)
- Read token lifetime from OneTimeLogin.tokenLifeTime (was wrongly prefixed with Auth.)