### PR TITLE
Fix Cake 5 SelectQuery type-hint in OneTimeLoginLinkBehavior

### DIFF
--- a/src/Model/Behavior/OneTimeLoginLinkBehavior.php
+++ b/src/Model/Behavior/OneTimeLoginLinkBehavior.php
@@ -8,7 +8,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\I18n\DateTime;
 use Cake\ORM\Behavior;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use OutOfBoundsException;
 
 /**
@@ -103,11 +103,11 @@ class OneTimeLoginLinkBehavior extends Behavior
     /**
      * Find by username or email.
      *
-     * @param \Cake\ORM\Query $query The query builder.
+     * @param \Cake\ORM\Query\SelectQuery $query The query builder.
      * @param string|null $username Username or email.
-     * @return \Cake\ORM\Query
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findByUsernameOrEmail(Query $query, ?string $username = null): Query
+    public function findByUsernameOrEmail(SelectQuery $query, ?string $username = null): SelectQuery
     {
         if (empty($username)) {
             throw new OutOfBoundsException('Missing username');
@@ -124,11 +124,11 @@ class OneTimeLoginLinkBehavior extends Behavior
     /**
      * Find by token
      *
-     * @param \Cake\ORM\Query $query
-     * @param string|null $token
-     * @return \Cake\ORM\Query
+     * @param \Cake\ORM\Query\SelectQuery $query The query builder.
+     * @param string|null $token Login token.
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findByOneTimeToken(Query $query, ?string $token = null): Query
+    public function findByOneTimeToken(SelectQuery $query, ?string $token = null): SelectQuery
     {
         if (empty($token)) {
             throw new OutOfBoundsException('Missing token');


### PR DESCRIPTION
## Bug

`Cake\ORM\Query` is a `class_alias` of `Cake\ORM\Query\SelectQuery` in Cake 5
(see `vendor/cakephp/cakephp/src/ORM/Query.php`), so the legacy import
worked at autoload time. But PHP's parameter type-check at the
`Cake\ORM\BehaviorRegistry::callFinder()` entry point rejects the alias
name (`Query`) used in the behavior's signatures when the runtime hands
it a real `SelectQuery` instance:

```
TypeError: CakeDC\Users\Model\Behavior\OneTimeLoginLinkBehavior::findByOneTimeToken():
Argument #1 ($query) must be of type Cake\ORM\Query, Cake\ORM\Query\SelectQuery given,
called in /var/www/html/vendor/cakephp/cakephp/src/ORM/Table.php on line 2774
```

## Trigger

This crashes **every authenticated request** when the `OneTimeToken`
authenticator (from `cakedc/auth`) is in the chain — which it is by
default on `cakedc/users` 16.x. The authenticator calls
`$users->loginWithToken($token)` on every request, which fires
`find('byOneTimeToken')`, which dispatches to the broken behavior finder.

Stack trace observed in production (Cake 5.3, cakedc/users 16.0.2):

```
#0 vendor/cakephp/cakephp/src/ORM/Table.php(2774): OneTimeLoginLinkBehavior->findByOneTimeToken(...)
#1 vendor/cakephp/cakephp/src/ORM/BehaviorRegistry.php(343): Table->invokeFinder(...)
#2 vendor/cakephp/cakephp/src/ORM/Table.php(2668): BehaviorRegistry->callFinder('byonetimetoken', ...)
#3 vendor/cakephp/cakephp/src/ORM/Table.php(1279): Table->callFinder('byOneTimeToken', ...)
#4 vendor/cakedc/users/src/Model/Behavior/OneTimeLoginLinkBehavior.php(68): Table->find('byOneTimeToken', ...)
#5 vendor/cakephp/cakephp/src/ORM/BehaviorRegistry.php(315): OneTimeLoginLinkBehavior->loginWithToken(...)
#6 vendor/cakephp/cakephp/src/ORM/Table.php(2852): BehaviorRegistry->call('loginwithtoken', ...)
#7 vendor/cakedc/auth/src/Authenticator/OneTimeTokenAuthenticator.php(33): Table->__call('loginWithToken', ...)
#8 vendor/cakedc/auth/src/Authentication/AuthenticationService.php(72): OneTimeTokenAuthenticator->authenticate(...)
#9 vendor/cakephp/authentication/src/Middleware/AuthenticationMiddleware.php(87): AuthenticationService->authenticate(...)
```

## Fix

Switch the import + finder signatures + docblocks from `Cake\ORM\Query`
to the canonical `Cake\ORM\Query\SelectQuery`. Behaviour identical, only
the type hint is corrected.

## Verification

Applied locally as a vendor patch and the TypeError is gone. All
authenticated downloads / signed URL token endpoints now resolve
identity normally through the chain.